### PR TITLE
PR for #10: Organize package.json with child nodes

### DIFF
--- a/leojs.leo
+++ b/leojs.leo
@@ -2931,7 +2931,7 @@ public get tooltip(): string {
         },
         {
             header: "node2",
-            body: "node2 body",
+            body: "", // Empty body should display icon without blue square
             children: []
         },
 

--- a/leojs.leo
+++ b/leojs.leo
@@ -7,15 +7,7 @@
 <find_panel_settings/>
 <vnodes>
 <v t="ekr.20201209145256.1"><vh>Startup</vh>
-<v t="ekr.20201209145256.2"><vh>@button backup</vh></v>
-<v t="ekr.20201209145330.1"><vh>@button write-leojs</vh>
-<v t="ekr.20201209145330.2"><vh>check_file_names</vh></v>
-<v t="ekr.20201209145330.3"><vh>check_nodes</vh></v>
-<v t="ekr.20201209145330.4"><vh>get_content</vh></v>
-<v t="ekr.20201209145330.5"><vh>main</vh></v>
-<v t="ekr.20201209145330.6"><vh>oops</vh></v>
-</v>
-<v t="ekr.20201209152713.1"><vh>script: split contributes/command section</vh></v>
+<v t="ekr.20201210035538.1"><vh>@file scripts.txt</vh></v>
 </v>
 <v t="felix.20201208214250.2"><vh>Documentation</vh>
 <v t="felix.20201208214319.1"><vh>@clean README.md</vh></v>
@@ -113,135 +105,7 @@
 </vnodes>
 <tnodes>
 <t tx="ekr.20201209145256.1"></t>
-<t tx="ekr.20201209145256.2">c.backup_helper(sub_dir='leojs')
-</t>
-<t tx="ekr.20201209145330.1">"""
-Update leojs.leo from the given list of nodes.
-
-This must be run from myLeojs.leo.
-"""
-g.cls()
-import os
-@others
-main(node_list = ['Startup', 'Documentation', 'Code'])
-</t>
-<t tx="ekr.20201209145330.2">def check_file_names():
-    """
-    Return the path to leojs.leo.
-    
-    Return None and give an error if:
-    - We are not running from myLeojs.leo or
-    - Leojs.leo does not exist.
-    """
-    if c.shortFileName() == 'leojs.leo':
-        oops("Don't run this script from leojs.leo")
-        return None
-    base_dir = os.path.dirname(c.fileName())
-    path = os.path.join(base_dir, 'leojs.leo')
-    if not os.path.exists(path):
-        oops(f"Not found: {path}")
-        return None
-    return os.path.normpath(path)</t>
-<t tx="ekr.20201209145330.3">def check_nodes(node_list):
-    """Return True if all nodes are found."""
-    result = []
-    for node in node_list:
-        p = g.findTopLevelNode(c, node, exact=True)
-        if p:
-            result.append(p.copy())
-        else:
-            oops(f"Top-level node {node} not found")
-            return []
-    return result</t>
-<t tx="ekr.20201209145330.4">def get_content(positions_list):
-    """
-    Return the desired contents of leoPyRef.leo.
-    
-    Based on code by Виталије Милошевић.
-    """
-    # Make only one copy for all calls.
-    fc = c.fileCommands
-    fc.currentPosition = c.p
-    fc.rootPosition = c.rootPosition()
-    fc.vnodesDict = {}
-    # Put the file
-    fc.outputFile = g.FileLikeObject()
-    fc.putProlog()
-    fc.putHeader()
-    fc.putGlobals()
-    fc.putPrefs()
-    fc.putFindSettings()
-    fc.put("&lt;vnodes&gt;\n")
-    for p in positions_list:
-        # An optimization: Write the next top-level node.
-        fc.putVnode(p, isIgnore=p.isAtIgnoreNode())
-    fc.put("&lt;/vnodes&gt;\n")
-    fc.putTnodes()
-    fc.putPostlog()
-    return fc.outputFile.getvalue()
-</t>
-<t tx="ekr.20201209145330.5">def main(node_list):
-    """The main line."""
-    c.endEditing()
-    path = check_file_names()
-    if not path:
-        return
-    positions_list = check_nodes(node_list)
-    if not positions_list:
-        return
-    content = get_content(positions_list)
-    with open(path, 'w', encoding="utf-8", newline='\n') as f:
-        f.write(content)
-    print('')
-    g.es_print(f"Updated {path}")
-</t>
-<t tx="ekr.20201209145330.6">def oops(message):
-    """Print an error message"""
-    print('')
-    g.es_print(message)
-    print('')</t>
 <t tx="ekr.20201209145358.1"></t>
-<t tx="ekr.20201209152713.1">"""
-Script: split the "commands" node of the "contributes" section into separate nodes.
-
-After running this script, it will be easy to alphabetize the commands and
-to group them with organizer nodes if desired.
-"""
-g.cls()
-root = g.findNodeAnywhere(c, 'commands')
-last = c.lastTopLevel()
-parent = last.insertAfter()
-parent.h = 'command tree'
-command_lines, level = [], 0
-for i, line in enumerate(g.splitLines(root.b)):
-    line_s = line.strip()
-    if command_lines:  # Accumulating a new node.
-        command_lines.append(line)
-        if line_s.endswith(('}', '},')):
-            level -= 1
-            if level == 0:
-                # End of command.
-                p = parent.insertAsLastChild()
-                h = command_lines[1].strip()
-                head = '"command": "leojs.'
-                assert h.startswith(head), (i, repr(h))
-                if h.endswith(','): h = h[:-1]
-                if h.endswith('"'): h = h[:-1]
-                p.h = h[len(head):]
-                p.b = ''.join(command_lines)
-                # g.printObj(command_lines)
-                command_lines = []
-        elif line_s.endswith('{'):
-            level += 1
-        else:
-            pass
-    elif line_s.endswith('{'):
-        level = 1
-        command_lines = [line]
-    elif line_s:
-        assert line_s.endswith('[') or line_s.startswith('],'), (i, repr(line))
-        # print('OUTSIDE', repr(line))
-c.redraw()</t>
 <t tx="ekr.20201210033748.1">"vscode:prepublish": "npm run package",
 "compile": "webpack --devtool nosources-source-map --config ./build/node-extension.webpack.config.js",
 "watch": "webpack --watch --devtool nosources-source-map --info-verbosity verbose --config ./build/node-extension.webpack.config.js",

--- a/leojs.leo
+++ b/leojs.leo
@@ -94,6 +94,7 @@
 </v>
 </v>
 <v t="felix.20201208214449.1"><vh>@clean package.json</vh>
+<v t="ekr.20201210033824.1"><vh>&lt;&lt; contributes &gt;&gt;</vh>
 <v t="felix.20201208222541.1"><vh>views</vh></v>
 <v t="felix.20201208221211.1"><vh>viewsWelcome</vh></v>
 <v t="felix.20201208220441.1"><vh>commands</vh></v>
@@ -104,6 +105,9 @@
 <v t="felix.20201208221847.1"><vh>view/item/context</vh></v>
 </v>
 <v t="felix.20201208221945.1"><vh>keybindings</vh></v>
+</v>
+<v t="ekr.20201210033748.1"><vh>&lt;&lt; scripts &gt;&gt;</vh></v>
+<v t="ekr.20201210033804.1"><vh>&lt;&lt; devDependencies &gt;&gt;</vh></v>
 </v>
 </v>
 </vnodes>
@@ -129,8 +133,8 @@ main(node_list = ['Startup', 'Documentation', 'Code'])
     - We are not running from myLeojs.leo or
     - Leojs.leo does not exist.
     """
-    if c.shortFileName() != 'myLeojs.leo':
-        oops('Run this script only from myLeojs.leo')
+    if c.shortFileName() == 'leojs.leo':
+        oops("Don't run this script from leojs.leo")
         return None
     base_dir = os.path.dirname(c.fileName())
     path = os.path.join(base_dir, 'leojs.leo')
@@ -200,7 +204,8 @@ main(node_list = ['Startup', 'Documentation', 'Code'])
 <t tx="ekr.20201209152713.1">"""
 Script: split the "commands" node of the "contributes" section into separate nodes.
 
-After running this script, it will be easy to alphabetize the commands and to group them with organizer nodes if desired.
+After running this script, it will be easy to alphabetize the commands and
+to group them with organizer nodes if desired.
 """
 g.cls()
 root = g.findNodeAnywhere(c, 'commands')
@@ -237,6 +242,32 @@ for i, line in enumerate(g.splitLines(root.b)):
         assert line_s.endswith('[') or line_s.startswith('],'), (i, repr(line))
         # print('OUTSIDE', repr(line))
 c.redraw()</t>
+<t tx="ekr.20201210033748.1">"vscode:prepublish": "npm run package",
+"compile": "webpack --devtool nosources-source-map --config ./build/node-extension.webpack.config.js",
+"watch": "webpack --watch --devtool nosources-source-map --info-verbosity verbose --config ./build/node-extension.webpack.config.js",
+"package": "webpack --mode production --config ./build/node-extension.webpack.config.js",
+"test-compile": "tsc -p ./",
+"test-watch": "tsc -watch -p ./",
+"pretest": "npm run test-compile &amp;&amp; npm run lint",
+"lint": "tslint -p ./",
+"OldLint": "eslint src --ext ts",
+"test": "node ./out/test/runTest.js"</t>
+<t tx="ekr.20201210033804.1">"@types/vscode": "^1.51.0",
+"@types/glob": "^7.1.3",
+"@types/mocha": "^8.0.0",
+"@types/node": "^12.11.7",
+"eslint": "^7.9.0",
+"@typescript-eslint/eslint-plugin": "^4.1.1",
+"@typescript-eslint/parser": "^4.1.1",
+"glob": "^7.1.6",
+"mocha": "^8.1.3",
+"typescript": "^4.0.2",
+"vscode-test": "^1.4.0",
+"ts-loader": "^8.0.3",
+"tslint": "^6.1.3",
+"webpack": "^4.44.1",
+"webpack-cli": "^3.3.12"</t>
+<t tx="ekr.20201210033824.1">@others</t>
 <t tx="felix.20201208214250.2"></t>
 <t tx="felix.20201208214319.1"># leojs
 
@@ -264,36 +295,13 @@ import { JsOutlineProvider } from './leoOutline';
   "activationEvents": ["*"],
   "main": "./dist/extension.js",
   "contributes": {
-    @others
+    &lt;&lt; contributes &gt;&gt;
   },
   "scripts": {
-    "vscode:prepublish": "npm run package",
-    "compile": "webpack --devtool nosources-source-map --config ./build/node-extension.webpack.config.js",
-    "watch": "webpack --watch --devtool nosources-source-map --info-verbosity verbose --config ./build/node-extension.webpack.config.js",
-    "package": "webpack --mode production --config ./build/node-extension.webpack.config.js",
-    "test-compile": "tsc -p ./",
-    "test-watch": "tsc -watch -p ./",
-    "pretest": "npm run test-compile &amp;&amp; npm run lint",
-    "lint": "tslint -p ./",
-    "OldLint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
+    &lt;&lt; scripts &gt;&gt;
   },
   "devDependencies": {
-    "@types/vscode": "^1.51.0",
-    "@types/glob": "^7.1.3",
-    "@types/mocha": "^8.0.0",
-    "@types/node": "^12.11.7",
-    "eslint": "^7.9.0",
-    "@typescript-eslint/eslint-plugin": "^4.1.1",
-    "@typescript-eslint/parser": "^4.1.1",
-    "glob": "^7.1.6",
-    "mocha": "^8.1.3",
-    "typescript": "^4.0.2",
-    "vscode-test": "^1.4.0",
-    "ts-loader": "^8.0.3",
-    "tslint": "^6.1.3",
-    "webpack": "^4.44.1",
-    "webpack-cli": "^3.3.12"
+    &lt;&lt; devDependencies &gt;&gt;
   }
 }
 </t>

--- a/scripts.txt
+++ b/scripts.txt
@@ -108,7 +108,12 @@ After running this script, it will be easy to alphabetize the commands and
 to group them with organizer nodes if desired.
 """
 g.cls()
-root = g.findNodeAnywhere(c, 'commands')
+parent_h = '@clean package.json'
+parent = g.findNodeAnywhere(c, parent_h)
+assert parent, f"Not found: {parent_h}"
+root_h = 'commands'
+root = g.findNodeInTree(c, parent, root_h)
+assert root, f"Not found: {root_h}"
 last = c.lastTopLevel()
 parent = last.insertAfter()
 parent.h = 'command tree'

--- a/scripts.txt
+++ b/scripts.txt
@@ -1,0 +1,150 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20201210035538.1: * @file scripts.txt
+#@@language python
+"""
+This file contains @button nodes and other scripts for use in leojs.leo.
+
+This file reduces git diffs agains leojs.leo itself.
+
+This file has a .txt extension to avoid warnings from pyflakes.
+"""
+#@+others
+#@+node:ekr.20201209145256.2: ** @button backup
+c.backup_helper(sub_dir='leojs')
+#@+node:ekr.20201209145330.1: ** @button write-leojs
+"""
+Update leojs.leo from the given list of nodes.
+
+This must be run from myLeojs.leo.
+"""
+g.cls()
+import os
+#@+others
+#@+node:ekr.20201209145330.2: *3* check_file_names
+def check_file_names():
+    """
+    Return the path to leojs.leo.
+    
+    Return None and give an error if:
+    - We are not running from myLeojs.leo or
+    - Leojs.leo does not exist.
+    """
+    if c.shortFileName() == 'leojs.leo':
+        oops("Don't run this script from leojs.leo")
+        return None
+    base_dir = os.path.dirname(c.fileName())
+    path = os.path.join(base_dir, 'leojs.leo')
+    if not os.path.exists(path):
+        oops(f"Not found: {path}")
+        return None
+    return os.path.normpath(path)
+#@+node:ekr.20201209145330.3: *3* check_nodes
+def check_nodes(node_list):
+    """Return True if all nodes are found."""
+    result = []
+    for node in node_list:
+        p = g.findTopLevelNode(c, node, exact=True)
+        if p:
+            result.append(p.copy())
+        else:
+            oops(f"Top-level node {node} not found")
+            return []
+    return result
+#@+node:ekr.20201209145330.4: *3* get_content
+def get_content(positions_list):
+    """
+    Return the desired contents of leoPyRef.leo.
+    
+    Based on code by Виталије Милошевић.
+    """
+    # Make only one copy for all calls.
+    fc = c.fileCommands
+    fc.currentPosition = c.p
+    fc.rootPosition = c.rootPosition()
+    fc.vnodesDict = {}
+    # Put the file
+    fc.outputFile = g.FileLikeObject()
+    fc.putProlog()
+    fc.putHeader()
+    fc.putGlobals()
+    fc.putPrefs()
+    fc.putFindSettings()
+    fc.put("<vnodes>\n")
+    for p in positions_list:
+        # An optimization: Write the next top-level node.
+        fc.putVnode(p, isIgnore=p.isAtIgnoreNode())
+    fc.put("</vnodes>\n")
+    fc.putTnodes()
+    fc.putPostlog()
+    return fc.outputFile.getvalue()
+#@+node:ekr.20201209145330.5: *3* main
+def main(node_list):
+    """The main line."""
+    c.endEditing()
+    path = check_file_names()
+    if not path:
+        return
+    positions_list = check_nodes(node_list)
+    if not positions_list:
+        return
+    content = get_content(positions_list)
+    with open(path, 'w', encoding="utf-8", newline='\n') as f:
+        f.write(content)
+    print('')
+    g.es_print(f"Updated {path}")
+#@+node:ekr.20201209145330.6: *3* oops
+def oops(message):
+    """Print an error message"""
+    print('')
+    g.es_print(message)
+    print('')
+#@-others
+main(node_list = ['Startup', 'Documentation', 'Code'])
+#@+node:ekr.20201209152713.1: ** script: split contributes/command section
+"""
+Script: split the "commands" node of the "contributes" section into separate nodes.
+
+After running this script, it will be easy to alphabetize the commands and
+to group them with organizer nodes if desired.
+"""
+g.cls()
+root = g.findNodeAnywhere(c, 'commands')
+last = c.lastTopLevel()
+parent = last.insertAfter()
+parent.h = 'command tree'
+command_lines, level = [], 0
+for i, line in enumerate(g.splitLines(root.b)):
+    line_s = line.strip()
+    if command_lines:  # Accumulating a new node.
+        command_lines.append(line)
+        if line_s.endswith(('}', '},')):
+            level -= 1
+            if level == 0:
+                # End of command.
+                p = parent.insertAsLastChild()
+                h = command_lines[1].strip()
+                head = '"command": "leojs.'
+                assert h.startswith(head), (i, repr(h))
+                if h.endswith(','): h = h[:-1]
+                if h.endswith('"'): h = h[:-1]
+                p.h = h[len(head):]
+                p.b = ''.join(command_lines)
+                # g.printObj(command_lines)
+                command_lines = []
+        elif line_s.endswith('{'):
+            level += 1
+        else:
+            pass
+    elif line_s.endswith('{'):
+        level = 1
+        command_lines = [line]
+    elif line_s:
+        assert line_s.endswith('[') or line_s.startswith('],'), (i, repr(line))
+        # print('OUTSIDE', repr(line))
+c.redraw()
+#@+node:ekr.20201210035719.1: ** script: diff-pr
+import leo.commands.editFileCommands as efc
+x = efc.GitDiffController(c)
+x.diff_pull_request(branch_name = 'package.json')
+#@-others
+#@-leo


### PR DESCRIPTION
See #10.

- [x] Fix reversion: add section references back to package.json.
- [x] `@button write-leojs` script checks that it isn't being run from leojs.leo itself.
    That is, the script doesn't require that it be run from myLeojs.leo.
- [x] leojs.leo now uses @file scripts.txt to define scripts.
    This will reduce diffs against leojs.leo.