### PR TITLE
FixHeadlineEditing

### DIFF
--- a/leojs.leo
+++ b/leojs.leo
@@ -3680,7 +3680,9 @@ export class LeoUI extends NullGui {
 
     // * Edit/Insert Headline Input Box System made with 'createInputBox'.
     private _hib: undefined | vscode.InputBox;
+    private _hibInstances = 0;
     private _hibResolve: undefined | ((value: string | PromiseLike&lt;string | undefined&gt; | undefined) =&gt; void);
+    private _onDidHideResolve: undefined | ((value: PromiseLike&lt;void&gt; | undefined) =&gt; void);
     private _hibLastValue: undefined | string;
     private _hibDisposables: vscode.Disposable[] = [];
 
@@ -4233,9 +4235,9 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
 
     // ! CHECK IF THIS IS NEEDED !
     // TODO ?
-    if (this._focusInterrupt) {
-        w_finalFocus = Focus.NoChange; // Going to use last state
-    }
+    // if (this._focusInterrupt) {
+    //     w_finalFocus = Focus.NoChange; // Going to use last state
+    // }
 
     this.setupRefresh(
         w_finalFocus,
@@ -4251,6 +4253,8 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
         prompt: p_prompt || Constants.USER_MESSAGES.PROMPT_EDIT_HEADLINE,
     };
     let p_newHeadline = await this._showHeadlineInputBox(w_headlineInputOptions);
+    console.log('finished awaiting in editHeadline');
+
     if (p_newHeadline &amp;&amp; p_newHeadline !== "\n") {
         let w_truncated = false;
         if (p_newHeadline.indexOf("\n") &gt;= 0) {
@@ -4281,6 +4285,12 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
             this.showOutline(true);
         }
     }
+    if (this._onDidHideResolve) {
+        console.log('RESOLVING!');
+
+        this._onDidHideResolve(undefined);
+        this._onDidHideResolve = undefined;
+    }
     return w_p;
 }
 
@@ -4293,14 +4303,17 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
  * @returns Thenable that resolves when done
  */
 public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_asChild: boolean): Promise&lt;unknown&gt; {
+    const test = Math.floor(Math.random() * 10) + 1;
+    console.log("starting", test);
 
     await this.triggerBodySave(true);
+    console.log("after triggerBodySave", test);
 
     let w_finalFocus: Focus = p_fromOutline ? Focus.Outline : Focus.Body; // Use w_fromOutline for where we intend to leave focus when done with the insert
 
-    if (this._focusInterrupt) {
-        w_finalFocus = Focus.NoChange; // Going to use last state
-    }
+    // if (this._focusInterrupt) {
+    //     w_finalFocus = Focus.NoChange; // Going to use last state
+    // }
 
     const w_headlineInputOptions: vscode.InputBoxOptions = {
         ignoreFocusOut: false,
@@ -4310,6 +4323,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
     };
 
     const p_newHeadline = await this._showHeadlineInputBox(w_headlineInputOptions);
+    console.log('finished awaiting in insertNode in ', test);
     // * if node has child and is expanded: turn p_asChild to true!
 
     this.lastCommandTimer = process.hrtime();
@@ -4355,7 +4369,15 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
         }
     }
     this.lastCommandTimer = undefined;
-    void this.launchRefresh();
+
+    if (this._onDidHideResolve) {
+        console.log('RESOLVING!', test);
+        this._onDidHideResolve(undefined);
+        this._onDidHideResolve = undefined;
+    } else {
+        void this.launchRefresh();
+    }
+
     return value;
 
 }
@@ -7497,7 +7519,9 @@ public gotSelectedNode(p_node: Position): void {
         let w_showBodyNoFocus: boolean = this.finalFocus.valueOf() !== Focus.Body; // Will preserve focus where it is without forcing into the body pane if true
         if (this._focusInterrupt) {
             this._focusInterrupt = false;
-            w_showBodyNoFocus = true;
+            if (this.finalFocus.valueOf() !== Focus.Body) {
+                w_showBodyNoFocus = true; // TODO MAY BE NECESSARY ?
+            }
         }
         if (!w_last || this._needLastSelectedRefresh) {
             // lastSelectedNode will be set in _tryApplyNodeToBody !
@@ -8749,20 +8773,37 @@ private _refreshUndoPane(): void {
  * @param p_forcedVsCodeSave Flag to also have vscode 'save' the content of this editor through the filesystem
  * @returns a promise that resolves when the possible saving process is finished
  */
-public triggerBodySave(p_forcedVsCodeSave?: boolean): Thenable&lt;unknown&gt; {
-
+public triggerBodySave(p_forcedVsCodeSave?: boolean, p_fromFocusChange?: boolean): Thenable&lt;unknown&gt; {
+    let functionName = "";
+    const err = new Error();
+    if (err.stack) {
+        const stack = err.stack.split('\n');
+        const line = stack[2];
+        const match = line.match(/at (\S+)/);
+        functionName = (match &amp;&amp; match[1]) || "";
+    }
     // * Check if headline edit input box is active. Validate it with current value.
-    if (this._hib) {
+    if (!p_fromFocusChange &amp;&amp; this._hib &amp;&amp; this._hib.enabled &amp;&amp; this._hibInstances) {
+
+
+
+        console.log('++++++++++++ IN triggerBodySave HIB +++++++++++++ HIDING! from :', functionName, 'instances: ', this._hibInstances);
+
+        if (this._hibInstances !== 1) {
+            console.log('ERROR this._hibInstances not 1 when hiding on triggerBodySave INTERRUPT:', this._hibInstances);
+        }
+        this._hib.enabled = false;
+
         this._hibLastValue = this._hib.value;
         this._hib.hide();
         // TODO : CHECK IF DELAYED RESOLVE NEEDED !
-        const w_resolveNextTick = new Promise&lt;void&gt;((p_resolve, p_reject) =&gt; {
-            setTimeout(() =&gt; {
-                this._focusInterrupt = true;
-                p_resolve();
-            }, 0);
+        const w_resolveAfterEditHeadline = new Promise&lt;void&gt;((p_resolve, p_reject) =&gt; {
+            this._onDidHideResolve = p_resolve;
+            this._focusInterrupt = true;
         });
-        return w_resolveNextTick;
+        return w_resolveAfterEditHeadline;
+    } else {
+        console.log('++++++++++++ IN triggerBodySave NORMAL from : ', functionName);
     }
 
     // * Save body to Leo if a change has been made to the body 'document' so far
@@ -12494,7 +12535,7 @@ private _onActiveEditorChanged(
         this._checkPreviewMode(p_editor);
     }
     if (!p_internalCall) {
-        void this.triggerBodySave(true); // Save in case edits were pending
+        void this.triggerBodySave(true, true); // Save in case edits were pending
     }
 
 }
@@ -12510,7 +12551,7 @@ public _changedTextEditorViewColumn(
     if (p_columnChangeEvent &amp;&amp; p_columnChangeEvent.textEditor.document.uri.scheme === Constants.URI_LEO_SCHEME) {
         this._checkPreviewMode(p_columnChangeEvent.textEditor);
     }
-    void this.triggerBodySave(true);
+    void this.triggerBodySave(true, true);
 }
 
 </t>
@@ -12530,7 +12571,7 @@ public _changedVisibleTextEditors(p_editors: readonly vscode.TextEditor[]): void
             }
         });
     }
-    void this.triggerBodySave(true);
+    void this.triggerBodySave(true, true);
 }
 
 </t>
@@ -12540,7 +12581,7 @@ public _changedVisibleTextEditors(p_editors: readonly vscode.TextEditor[]): void
  */
 public _changedWindowState(p_windowState: vscode.WindowState): void {
     // no other action
-    void this.triggerBodySave(true);
+    void this.triggerBodySave(true, true);
 }
 
 </t>
@@ -14692,6 +14733,10 @@ Although legal in js, it is NOT equivalent: A "for in" loop in js loops over the
  * Other Leo commands interrupt by accepting the value entered so far.
  */
 private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;string | undefined&gt; {
+    if (this._hibInstances) {
+        console.log('ERROR this._hibInstances is not zero when creating input box!', this._hibInstances);
+    }
+    console.log('-------------------- IN _showHeadlineInputBox --------------------+');
 
     const hib = vscode.window.createInputBox();
     this._hibLastValue = undefined; // Prepare for 'cancel' as default.
@@ -14702,14 +14747,24 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         hib.valueSelection = p_options.valueSelection;
         hib.prompt = p_options.prompt;
         this._hibDisposables.push(hib.onDidAccept(() =&gt; {
+            console.log('-------------------- IN onDidAccept --------------------+');
+
             if (this._hib) {
+                if (this._hibInstances !== 1) {
+                    console.log('ERROR this._hibInstances not 1 when hiding on accept', this._hibInstances);
+                }
+                this._hib.enabled = false;
                 this._hibLastValue = this._hib.value;
+
+
                 this._hib.hide();
             }
         }, this));
         this._hibResolve = p_resolve;
         // onDidHide handles CANCEL AND ACCEPT AND INTERCEPT !
         this._hibDisposables.push(hib.onDidHide(() =&gt; {
+            console.log('-------------------- IN onDidHide --------------------+ _hibInstances: ', this._hibInstances);
+            this._hibInstances -= 1;
             this.leoStates.leoEditHeadline = false;
             if (this._hibResolve) {
                 // RESOLVE whatever value was set otherwise undefined will mean 'canceled'.
@@ -14722,6 +14777,9 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
                 this._hibDisposables = [];
                 this._hibResolve = undefined;
                 this._hib = undefined;
+            } else {
+                console.log('ERROR ON onDidHide NO _hibResolve !');
+
             }
         }, this));
         this._hibDisposables.push(hib);
@@ -14729,6 +14787,7 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         // setup finished, set command context and show it! 
         this._hib = hib;
         this.leoStates.leoEditHeadline = true;
+        this._hibInstances += 1;
         this._hib.show();
     });
     return q_headlineInputBox;

--- a/leojs.leo
+++ b/leojs.leo
@@ -3679,7 +3679,6 @@ export class LeoUI extends NullGui {
 
     // * Edit/Insert Headline Input Box System made with 'createInputBox'.
     private _hib: undefined | vscode.InputBox;
-    private _hibInstances = 0;
     private _hibResolve: undefined | ((value: string | PromiseLike&lt;string | undefined&gt; | undefined) =&gt; void);
     private _onDidHideResolve: undefined | ((value: PromiseLike&lt;void&gt; | undefined) =&gt; void);
     private _hibLastValue: undefined | string;
@@ -8786,30 +8785,20 @@ private _refreshUndoPane(): void {
  * @returns a promise that resolves when the possible saving process is finished
  */
 public triggerBodySave(p_forcedVsCodeSave?: boolean, p_fromFocusChange?: boolean): Thenable&lt;unknown&gt; {
-    let functionName = "";
-    const err = new Error();
-    if (err.stack) {
-        const stack = err.stack.split('\n');
-        const line = stack[2];
-        const match = line.match(/at (\S+)/);
-        functionName = (match &amp;&amp; match[1]) || "";
-    }
+
     // * Check if headline edit input box is active. Validate it with current value.
     if (!p_fromFocusChange &amp;&amp; this._hib &amp;&amp; this._hib.enabled) {
-        console.log('++++++++++++ IN triggerBodySave HIB -&gt; HIDING! Was called from :', functionName, ' instances: ' + this._hibInstances.toString());
-        if (this._hibInstances !== 1) {
-            console.log('ERROR this._hibInstances not 1 when hiding on triggerBodySave INTERRUPT. instances: ' + this._hibInstances.toString());
-        }
         this._hibInterrupted = true;
         this._hib.enabled = false;
         this._hibLastValue = this._hib.value;
         this._hib.hide();
+        if (this._onDidHideResolve) {
+            console.error('IN triggerBodySave AND _onDidHideResolve PROMISE ALREADY EXISTS!');
+        }
         const w_resolveAfterEditHeadline = new Promise&lt;void&gt;((p_resolve, p_reject) =&gt; {
             this._onDidHideResolve = p_resolve;
         });
         return w_resolveAfterEditHeadline;
-    } else {
-        console.log('++++++++++++ IN triggerBodySave NORMAL from : ', functionName);
     }
 
     // * Save body to Leo if a change has been made to the body 'document' so far
@@ -11462,10 +11451,8 @@ public cleanupBody(): Thenable&lt;any&gt; {
         const w_edit = new vscode.WorkspaceEdit();
         w_edit.deleteFile(this.bodyUri, { ignoreIfNotExists: true });
         q_edit = vscode.workspace.applyEdit(w_edit).then(() =&gt; {
-            // console.log('applyEdit done');
             return true;
         }, () =&gt; {
-            // console.log('applyEdit failed');
             return false;
         });
     } else {
@@ -11473,10 +11460,8 @@ public cleanupBody(): Thenable&lt;any&gt; {
     }
     Promise.all([q_save, q_edit])
         .then(() =&gt; {
-            // console.log('cleaned both');
             return this.closeBody();
         }, () =&gt; {
-            // console.log('cleaned both failed');
             return true;
         });
 
@@ -14637,10 +14622,6 @@ Although legal in js, it is NOT equivalent: A "for in" loop in js loops over the
  * Other Leo commands interrupt by accepting the value entered so far.
  */
 private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;string | undefined&gt; {
-    if (this._hibInstances) {
-        console.log('ERROR this._hibInstances is not zero when creating input box!  _hibInstances was: ' + this._hibInstances.toString());
-    }
-    console.log('-------------------- IN _showHeadlineInputBox _hibInstances was: ' + this._hibInstances.toString());
 
     const hib = vscode.window.createInputBox();
     this._hibLastValue = undefined; // Prepare for 'cancel' as default.
@@ -14651,27 +14632,19 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         hib.valueSelection = p_options.valueSelection;
         hib.prompt = p_options.prompt;
         this._hibDisposables.push(hib.onDidAccept(() =&gt; {
-
-            console.log('-------------------- IN onDidAccept _hibInstances was: ');
-
             if (this._hib) {
-                if (this._hibInstances !== 1) {
-                    console.log('ERROR this._hibInstances not 1 when hiding on accept' + this._hibInstances.toString());
-                }
                 this._hib.enabled = false;
                 this._hibLastValue = this._hib.value;
-
-
                 this._hib.hide();
             }
         }, this));
+        if (this._hibResolve) {
+            console.error('IN _showHeadlineInputBox AND THE _hibResolve PROMISE ALREADY EXISTS!');
+        }
         this._hibResolve = p_resolve;
         // onDidHide handles CANCEL AND ACCEPT AND INTERCEPT !
         this._hibDisposables.push(hib.onDidHide(() =&gt; {
 
-            console.log('-------------------- IN onDidHide _hibInstances was: ' + this._hibInstances.toString());
-
-            this._hibInstances -= 1;
             this.leoStates.leoEditHeadline = false;
             if (this._hibResolve) {
                 // RESOLVE whatever value was set otherwise undefined will mean 'canceled'.
@@ -14686,15 +14659,12 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
                 this._hib = undefined;
             } else {
                 console.log('ERROR ON onDidHide NO _hibResolve !');
-
             }
         }, this));
         this._hibDisposables.push(hib);
-
         // setup finished, set command context and show it! 
         this._hib = hib;
         this.leoStates.leoEditHeadline = true;
-        this._hibInstances += 1;
         this._hib.show();
     });
     return q_headlineInputBox;

--- a/leojs.leo
+++ b/leojs.leo
@@ -176,6 +176,7 @@
 <v t="felix.20221002124249.1"><vh>_showMinibufferHistory</vh></v>
 <v t="felix.20221002124535.1"><vh>_doMinibufferCommand</vh></v>
 <v t="felix.20230222212520.1"><vh>_addToMinibufferHistory</vh></v>
+<v t="felix.20231029213146.1"><vh>_showHeadlineInputBox</vh></v>
 <v t="felix.20201214202759.1"><vh>editHeadline</vh></v>
 <v t="felix.20201214202800.1"><vh>insertNode</vh></v>
 <v t="felix.20211204181418.1"><vh>_insertAndSetHeadline</vh></v>
@@ -3675,13 +3676,11 @@ export class LeoUI extends NullGui {
     // * Status Bar
     // private _leoStatusBar: LeoStatusBar; // ! NOT USED UNTIL VSCODE API SUPPORTS "CURRENT-FOCUS" LOCATION INFO !
 
-    // * Edit/Insert Headline Input Box options instance, setup so clicking outside cancels the headline change
-    private _headlineInputOptions: vscode.InputBoxOptions = {
-        ignoreFocusOut: false,
-        value: '',
-        valueSelection: undefined,
-        prompt: '',
-    };
+    // * Edit/Insert Headline Input Box System made with 'createInputBox'.
+    private _hib: undefined | vscode.InputBox;
+    private _hibResolve: undefined | ((value: string | PromiseLike&lt;string | undefined&gt; | undefined) =&gt; void);
+    private _hibLastValue: undefined | string;
+    private _hibDisposables: vscode.Disposable[] = [];
 
     // * Timing
     private _needLastSelectedRefresh = false; // USED IN showBody
@@ -4228,16 +4227,28 @@ public async minibuffer(): Promise&lt;unknown&gt; {
  */
 public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?: string): Promise&lt;Position&gt; {
     await this.triggerBodySave(true);
+    let w_finalFocus: Focus = p_fromOutline ? Focus.Outline : Focus.Body; // Use w_fromOutline for where we intend to leave focus when done with the insert
+
+    // ! CHECK IF THIS IS NEEDED !
+    // TODO ?
+    if (this._focusInterrupt) {
+        w_finalFocus = Focus.NoChange; // Going to use last state
+    }
+
     this.setupRefresh(
-        p_fromOutline ? Focus.Outline : Focus.Body,
+        w_finalFocus,
         { tree: true, states: true }
     );
     const c = g.app.windowList[this.frameIndex].c;
     const u = c.undoer;
     const w_p: Position = p_node || c.p;
-    this._headlineInputOptions.prompt = p_prompt || Constants.USER_MESSAGES.PROMPT_EDIT_HEADLINE;
-    this._headlineInputOptions.value = w_p.h; // preset input pop up
-    let p_newHeadline = await vscode.window.showInputBox(this._headlineInputOptions);
+    const w_headlineInputOptions: vscode.InputBoxOptions = {
+        ignoreFocusOut: false,
+        value: w_p.h,  // preset input pop up
+        valueSelection: undefined,
+        prompt: p_prompt || Constants.USER_MESSAGES.PROMPT_EDIT_HEADLINE,
+    };
+    let p_newHeadline = await this._showHeadlineInputBox(w_headlineInputOptions);
     if (p_newHeadline &amp;&amp; p_newHeadline !== "\n") {
         let w_truncated = false;
         if (p_newHeadline.indexOf("\n") &gt;= 0) {
@@ -4282,19 +4293,20 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
 public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_interrupt: boolean, p_asChild: boolean): Promise&lt;unknown&gt; {
     await this.triggerBodySave(true);
     let w_finalFocus: Focus = p_fromOutline ? Focus.Outline : Focus.Body; // Use w_fromOutline for where we intend to leave focus when done with the insert
-    if (p_interrupt) {
-        this._focusInterrupt = true;
+
+    if (this._focusInterrupt) {
         w_finalFocus = Focus.NoChange; // Going to use last state
     }
-    void this.triggerBodySave(true); // Don't wait for saving to resolve because we're waiting for user input anyways
-    if (p_asChild) {
-        this._headlineInputOptions.prompt = Constants.USER_MESSAGES.PROMPT_INSERT_CHILD;
-    } else {
-        this._headlineInputOptions.prompt = Constants.USER_MESSAGES.PROMPT_INSERT_NODE;
-    }
-    this._headlineInputOptions.value = Constants.USER_MESSAGES.DEFAULT_HEADLINE;
 
-    const p_newHeadline = await vscode.window.showInputBox(this._headlineInputOptions);
+    void this.triggerBodySave(true); // Don't wait for saving to resolve because we're waiting for user input anyways
+    const w_headlineInputOptions: vscode.InputBoxOptions = {
+        ignoreFocusOut: false,
+        value: Constants.USER_MESSAGES.DEFAULT_HEADLINE,
+        valueSelection: undefined,
+        prompt: p_asChild ? Constants.USER_MESSAGES.PROMPT_INSERT_CHILD : Constants.USER_MESSAGES.PROMPT_INSERT_NODE
+    };
+
+    const p_newHeadline = await this._showHeadlineInputBox(w_headlineInputOptions);
     // * if node has child and is expanded: turn p_asChild to true!
 
     this.lastCommandTimer = process.hrtime();
@@ -8775,11 +8787,27 @@ private _refreshUndoPane(): void {
 </t>
 <t tx="felix.20211204144931.1"></t>
 <t tx="felix.20211204144931.2">/**
- * * Save body to Leo if its dirty. That is, only if a change has been made to the body 'document' so far
+ * * Validate headline edit input box if active, or, Save body to the Leo app if its dirty.
+ *   That is, only if a change has been made to the body 'document' so far
  * @param p_forcedVsCodeSave Flag to also have vscode 'save' the content of this editor through the filesystem
  * @returns a promise that resolves when the possible saving process is finished
  */
 public triggerBodySave(p_forcedVsCodeSave?: boolean): Thenable&lt;unknown&gt; {
+
+    // * Check if headline edit input box is active. Validate it with current value.
+    if (this._hib) {
+        this._hibLastValue = this._hib.value;
+        this._hib.hide();
+        // TODO : CHECK IF DELAYED RESOLVE NEEDED !
+        const w_resolveNextTick = new Promise&lt;void&gt;((p_resolve, p_reject) =&gt; {
+            setTimeout(() =&gt; {
+                this._focusInterrupt = true;
+                p_resolve();
+            }, 0);
+        });
+        return w_resolveNextTick;
+    }
+
     // * Save body to Leo if a change has been made to the body 'document' so far
     let q_savePromise: Thenable&lt;boolean&gt;;
     if (
@@ -9021,9 +9049,9 @@ private _insertAndSetHeadline(p_name?: string, p_asChild?: boolean): any {
  * @param p_string actual string content to go onto the clipboard
  * @returns a promise that resolves when the string is put on the clipboard
  */
-public replaceClipboardWith(s: string): Thenable&lt;void&gt; {
+public replaceClipboardWith(s: string): Thenable&lt;string&gt; {
     this.clipboardContents = s; // also set immediate clipboard string
-    return vscode.env.clipboard.writeText(s);
+    return vscode.env.clipboard.writeText(s).then(() =&gt; { return s; });
 }
 
 </t>
@@ -14700,6 +14728,50 @@ a "for in" loop in python loops over the values which is equivalent to a "for of
 
 Although legal in js, it is NOT equivalent: A "for in" loop in js loops over the keys, not the values.
 
+
+</t>
+<t tx="felix.20231029213146.1">/**
+ * Show a headline input box that resolves to undefined only with escape.
+ * Other Leo commands interrupt by accepting the value entered so far.
+ */
+private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;string | undefined&gt; {
+
+    const hib = vscode.window.createInputBox();
+    this._hibLastValue = undefined; // Prepare for 'cancel' as default.
+    const q_headlineInputBox = new Promise&lt;string | undefined&gt;((p_resolve, p_reject) =&gt; {
+
+        hib.ignoreFocusOut = !!p_options.ignoreFocusOut;
+        hib.value = p_options.value!;
+        hib.valueSelection = p_options.valueSelection;
+        hib.prompt = p_options.prompt;
+        this._hibDisposables.push(hib.onDidAccept(() =&gt; {
+            if (this._hib) {
+                this._hibLastValue = this._hib.value;
+                this._hib.hide();
+            }
+        }, this));
+        this._hibResolve = p_resolve;
+        // onDidHide handles CANCEL AND ACCEPT AND INTERCEPT !
+        this._hibDisposables.push(hib.onDidHide(() =&gt; {
+            if (this._hibResolve) {
+                this._hibResolve(this._hibLastValue);
+
+                for (const disp of this._hibDisposables) {
+                    disp.dispose();
+                }
+                this._hibDisposables = [];
+                this._hibResolve = undefined;
+                this._hib = undefined;
+            }
+        }, this));
+        this._hibDisposables.push(hib);
+
+        // setup finished, show it! 
+        this._hib = hib;
+        this._hib.show();
+    });
+    return q_headlineInputBox;
+}
 
 </t>
 </tnodes>

--- a/leojs.leo
+++ b/leojs.leo
@@ -4253,9 +4253,8 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
         prompt: p_prompt || Constants.USER_MESSAGES.PROMPT_EDIT_HEADLINE,
     };
     let p_newHeadline = await this._showHeadlineInputBox(w_headlineInputOptions);
-    console.log('finished awaiting in editHeadline');
 
-    if (p_newHeadline &amp;&amp; p_newHeadline !== "\n") {
+    if ((p_newHeadline || p_newHeadline === "") &amp;&amp; p_newHeadline !== "\n") {
         let w_truncated = false;
         if (p_newHeadline.indexOf("\n") &gt;= 0) {
             p_newHeadline = p_newHeadline.split("\n")[0];
@@ -4286,8 +4285,6 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
         }
     }
     if (this._onDidHideResolve) {
-        console.log('RESOLVING!');
-
         this._onDidHideResolve(undefined);
         this._onDidHideResolve = undefined;
     }
@@ -4303,8 +4300,6 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
  * @returns Thenable that resolves when done
  */
 public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_asChild: boolean): Promise&lt;unknown&gt; {
-    const test = Math.floor(Math.random() * 10) + 1;
-    console.log("starting", test);
 
     let w_hadHib = false;
     if (this._hib &amp;&amp; this._hib.enabled) {
@@ -4317,8 +4312,8 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
     }
 
     await this.triggerBodySave(true);
-    console.log("after triggerBodySave", test);
 
+    // * if node has child and is expanded: turn p_asChild to true!
     const w_headlineInputOptions: vscode.InputBoxOptions = {
         ignoreFocusOut: false,
         value: Constants.USER_MESSAGES.DEFAULT_HEADLINE,
@@ -4327,16 +4322,11 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
     };
 
     const p_newHeadline = await this._showHeadlineInputBox(w_headlineInputOptions);
-    console.log('finished awaiting in insertNode in ', test);
-    // * if node has child and is expanded: turn p_asChild to true!
 
-    // IF WE WERE INTERUPTED DO THIS:
-    //  w_finalFocus = Focus.NoChange; // Going to use last state
     if (this._hibInterrupted) {
         w_finalFocus = Focus.NoChange;
         this._hibInterrupted = false;
     }
-
 
     this.lastCommandTimer = process.hrtime();
     if (this.commandTimer === undefined) {
@@ -4383,7 +4373,6 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
     this.lastCommandTimer = undefined;
 
     if (this._onDidHideResolve) {
-        console.log('RESOLVING!', test);
         this._onDidHideResolve(undefined);
         this._onDidHideResolve = undefined;
     } else {
@@ -14644,7 +14633,9 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         this._hibResolve = p_resolve;
         // onDidHide handles CANCEL AND ACCEPT AND INTERCEPT !
         this._hibDisposables.push(hib.onDidHide(() =&gt; {
-
+            if (this._hib) {
+                this._hibLastValue = this._hib.value; // * FORCE VALUE EVEN WHEN CANCELLING LIKE IN ORIGINAL LEO !
+            }
             this.leoStates.leoEditHeadline = false;
             if (this._hibResolve) {
                 // RESOLVE whatever value was set otherwise undefined will mean 'canceled'.

--- a/leojs.leo
+++ b/leojs.leo
@@ -313,6 +313,7 @@
 <v t="felix.20201214151447.10"><vh>leoCanPromote &amp; helper</vh></v>
 <v t="felix.20201214151447.11"><vh>leoCanDehoist &amp; helper</vh></v>
 <v t="felix.20230403223923.1"><vh>leoTopHoistChapter &amp; helper</vh></v>
+<v t="felix.20231030200350.1"><vh>leoEditHeadline &amp; helper</vh></v>
 </v>
 <v t="felix.20201214151447.12"><vh>Selected Node Flags</vh>
 <v t="felix.20201214151447.13"><vh>leoMarked</vh></v>
@@ -1640,19 +1641,19 @@ export async function activate(p_context: vscode.ExtensionContext) {
 }
 
 </t>
-<t tx="felix.20201214150149.10">[CMD.INSERT, (p_node: Position) =&gt; p_leoUI.insertNode(p_node, true, false, false)],
-[CMD.INSERT_SELECTION, () =&gt; p_leoUI.insertNode(U, false, false, false)],
-[CMD.INSERT_SELECTION_FO, () =&gt; p_leoUI.insertNode(U, true, false, false)],
+<t tx="felix.20201214150149.10">[CMD.INSERT, (p_node: Position) =&gt; p_leoUI.insertNode(p_node, true, false)],
+[CMD.INSERT_SELECTION, () =&gt; p_leoUI.insertNode(U, false, false)],
+[CMD.INSERT_SELECTION_FO, () =&gt; p_leoUI.insertNode(U, true, false)],
 // Special command for when inserting rapidly more than one node without
 // even specifying a headline label, e.g. spamming CTRL+I rapidly.
-[CMD.INSERT_SELECTION_INTERRUPT, () =&gt; p_leoUI.insertNode(U, false, true, false)],
+// [CMD.INSERT_SELECTION_INTERRUPT, () =&gt; p_leoUI.insertNode(U, false, true, false)],
 
-[CMD.INSERT_CHILD, (p_node: Position) =&gt; p_leoUI.insertNode(p_node, true, false, true)],
-[CMD.INSERT_CHILD_SELECTION, () =&gt; p_leoUI.insertNode(U, false, false, true)],
-[CMD.INSERT_CHILD_SELECTION_FO, () =&gt; p_leoUI.insertNode(U, true, false, true)],
+[CMD.INSERT_CHILD, (p_node: Position) =&gt; p_leoUI.insertNode(p_node, true, true)],
+[CMD.INSERT_CHILD_SELECTION, () =&gt; p_leoUI.insertNode(U, false, true)],
+[CMD.INSERT_CHILD_SELECTION_FO, () =&gt; p_leoUI.insertNode(U, true, true)],
 // Special command for when inserting rapidly more than one node without
 // even specifying a headline label, e.g. spamming CTRL+I rapidly.
-[CMD.INSERT_CHILD_SELECTION_INTERRUPT, () =&gt; p_leoUI.insertNode(U, false, true, true)],
+// [CMD.INSERT_CHILD_SELECTION_INTERRUPT, () =&gt; p_leoUI.insertNode(U, false, true, true)],
 
 [CMD.CLONE, (p_node: Position) =&gt; p_leoUI.command(LEOCMD.CLONE_PNODE, { node: p_node, refreshType: REFRESH_TREE_BODY, finalFocus: Focus.Outline, keepSelection: true })],
 [CMD.CLONE_SELECTION, () =&gt; p_leoUI.command(LEOCMD.CLONE_PNODE, { refreshType: REFRESH_TREE, finalFocus: Focus.Body })],
@@ -2503,6 +2504,7 @@ public static CONTEXT_FLAGS = {
     LEO_CAN_DEHOIST: "leojsCanDehoist",
     LEO_CAN_HOIST: "leojsCanHoist", // isNotRoot equivalent, Computed by hand
     LEO_TOP_HOIST_CHAPTER: "leojsTopHoistChapter",
+    LEO_EDIT_HEADLINE: "leojsEditHeadline",
 
     // 'states' flags about current selection, for visibility and commands availability
     SELECTED_MARKED: "leojsMarked", // no need for unmarked here, use !leojsMarked
@@ -4290,15 +4292,16 @@ public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?:
  * @param p_interrupt Signifies the insert action is actually interrupting itself (e.g. rapid CTRL+I actions by the user)
  * @returns Thenable that resolves when done
  */
-public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_interrupt: boolean, p_asChild: boolean): Promise&lt;unknown&gt; {
+public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_asChild: boolean): Promise&lt;unknown&gt; {
+
     await this.triggerBodySave(true);
+
     let w_finalFocus: Focus = p_fromOutline ? Focus.Outline : Focus.Body; // Use w_fromOutline for where we intend to leave focus when done with the insert
 
     if (this._focusInterrupt) {
         w_finalFocus = Focus.NoChange; // Going to use last state
     }
 
-    void this.triggerBodySave(true); // Don't wait for saving to resolve because we're waiting for user input anyways
     const w_headlineInputOptions: vscode.InputBoxOptions = {
         ignoreFocusOut: false,
         value: Constants.USER_MESSAGES.DEFAULT_HEADLINE,
@@ -5079,26 +5082,6 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   }
 },
 {
-  "command": "leojs.insertNodeSelectionInterrupt",
-  "category": "Leojs",
-  "title": "Insert Node",
-  "enablement": "leojsTreeOpened",
-  "icon": {
-    "light": "resources/light/plus.svg",
-    "dark": "resources/dark/plus.svg"
-  }
-},
-{
-  "command": "leojs.insertChildNodeSelectionInterrupt",
-  "category": "Leojs",
-  "title": "Insert Child",
-  "enablement": "leojsTreeOpened",
-  "icon": {
-    "light": "resources/light/insert-child.svg",
-    "dark": "resources/dark/insert-child.svg"
-  }
-},
-{
   "command": "leojs.cloneNode",
   "category": "Leojs",
   "title": "Clone Node",
@@ -5712,19 +5695,11 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "when": "false"
 },
 {
-  "command": "leojs.insertNodeSelectionInterrupt",
-  "when": "false"
-},
-{
   "command": "leojs.insertChildNode",
   "when": "false"
 },
 {
   "command": "leojs.insertChildNodeSelectionFromOutline",
-  "when": "false"
-},
-{
-  "command": "leojs.insertChildNodeSelectionInterrupt",
   "when": "false"
 },
 {
@@ -6117,18 +6092,18 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.executeScript",
   "key": "ctrl+b",
   "mac": "cmd+b",
-  "when": "leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.minibuffer",
   "key": "alt+x",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 </t>
 <t tx="felix.20201214205159.69">{
   "command": "leojs.showOutline",
   "key": "alt+t",
-  "when": "leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs || leojsFindFocus || focusedView =~ /^leojsUndos|^leojsFindPanel|^leojsDocuments|^leojsGoto|^leojsButtons/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs || leojsFindFocus || focusedView =~ /^leojsUndos|^leojsFindPanel|^leojsDocuments|^leojsGoto|^leojsButtons/"
 },
 {
   "command": "leojs.showOutline",
@@ -6145,13 +6120,13 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.showBody",
   "key": "alt+d",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.showBody",
   "key": "ctrl+g",
   "mac": "cmd+g",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.showBody",
@@ -6168,13 +6143,13 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.tabCycleNext",
   "key": "ctrl+tab",
   "mac": "cmd+tab",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.saveLeoFileFromOutline",
   "key": "ctrl+s",
   "mac": "cmd+s",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.saveLeoFile",
@@ -6186,13 +6161,13 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.newLeoFile",
   "key": "ctrl+n",
   "mac": "cmd+n",
-  "when": "editorTextFocus &amp;&amp; resourceScheme == leojs || leojsFindFocus || sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || editorTextFocus &amp;&amp; resourceScheme == leojs || leojsFindFocus || sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.openLeoFile",
   "key": "ctrl+o",
   "mac": "cmd+o",
-  "when": "editorTextFocus &amp;&amp; resourceScheme == leojs || leojsFindFocus || sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || editorTextFocus &amp;&amp; resourceScheme == leojs || leojsFindFocus || sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.writeAtFileNodes",
@@ -6204,7 +6179,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.writeAtFileNodesFromOutline",
   "key": "ctrl+shift+w",
   "mac": "cmd+shift+w",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.writeDirtyAtFileNodes",
@@ -6216,7 +6191,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.writeDirtyAtFileNodesFromOutline",
   "key": "ctrl+shift+q",
   "mac": "cmd+shift+q",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 </t>
 <t tx="felix.20201214205159.71">{
@@ -6227,7 +6202,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.contractAllFromOutline",
   "key": "alt+-",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 </t>
 <t tx="felix.20201214205159.72">{
@@ -6240,7 +6215,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.editSelectedHeadlineFromOutline",
   "key": "ctrl+h",
   "mac": "cmd+h",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments|^leojsButtons|^leojsUndos/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments|^leojsButtons|^leojsUndos/"
 },
 </t>
 <t tx="felix.20201214205159.73">{
@@ -6253,7 +6228,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.markSelectionFromOutline",
   "key": "ctrl+m",
   "mac": "cmd+m",
-  "when": "leojsTreeOpened &amp;&amp; !leojsMarked &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; !leojsMarked &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.unmarkSelection",
@@ -6265,20 +6240,20 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.unmarkSelectionFromOutline",
   "key": "ctrl+m",
   "mac": "cmd+m",
-  "when": "leojsTreeOpened &amp;&amp; leojsMarked &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; leojsMarked &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 </t>
 <t tx="felix.20201214205159.74">{
   "command": "leojs.extract",
   "key": "ctrl+shift+d",
   "mac": "cmd+shift+d",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; editorHasSelection &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; editorHasSelection &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.extractNames",
   "key": "ctrl+shift+n",
   "mac": "cmd+shift+n",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; editorHasSelection &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; editorHasSelection &amp;&amp; resourceScheme == leojs"
 },
 </t>
 <t tx="felix.20201214205159.75">{
@@ -6297,7 +6272,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.moveOutlineDownSelectionFromOutline",
   "key": "ctrl+d",
   "mac": "cmd+d",
-  "when": "leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.moveOutlineDownSelectionFromOutline",
@@ -6326,7 +6301,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.moveOutlineLeftSelectionFromOutline",
   "key": "ctrl+l",
   "mac": "cmd+l",
-  "when": "leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.moveOutlineLeftSelectionFromOutline",
@@ -6355,7 +6330,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.moveOutlineRightSelectionFromOutline",
   "key": "ctrl+r",
   "mac": "cmd+r",
-  "when": "leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.moveOutlineRightSelectionFromOutline",
@@ -6384,7 +6359,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.moveOutlineUpSelectionFromOutline",
   "key": "ctrl+u",
   "mac": "cmd+u",
-  "when": "leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.moveOutlineUpSelectionFromOutline",
@@ -6406,7 +6381,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.sortSiblingsSelectionFromOutline",
   "key": "alt+a",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.promoteSelection",
@@ -6422,7 +6397,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "win": "ctrl+oem_4",
   "linux": "ctrl+[",
   "mac": "cmd+[BracketLeft]",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.demoteSelection",
@@ -6438,7 +6413,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "win": "ctrl+oem_6",
   "linux": "ctrl+]",
   "mac": "cmd+[BracketRight]",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.insertNodeSelection",
@@ -6450,13 +6425,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.insertNodeSelectionFromOutline",
   "key": "ctrl+i",
   "mac": "cmd+i",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
-},
-{
-  "command": "leojs.insertNodeSelectionInterrupt",
-  "key": "ctrl+i",
-  "mac": "cmd+i",
-  "when": "!terminalFocus &amp;&amp; !panelFocus &amp;&amp; leojsTreeOpened &amp;&amp; !sideBarFocus &amp;&amp; !editorTextFocus"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.insertNodeSelection",
@@ -6468,19 +6437,13 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.insertNodeSelectionFromOutline",
   "key": "shift+insert",
   "mac": "shift+insert",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.insertNodeSelectionFromOutline",
   "key": "insert",
   "mac": "insert",
   "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
-},
-{
-  "command": "leojs.insertNodeSelectionInterrupt",
-  "key": "shift+insert",
-  "mac": "shift+insert",
-  "when": "!terminalFocus &amp;&amp; !panelFocus &amp;&amp; leojsTreeOpened &amp;&amp; !sideBarFocus &amp;&amp; !editorTextFocus"
 },
 {
   "command": "leojs.insertChildNodeSelection",
@@ -6492,13 +6455,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.insertChildNodeSelectionFromOutline",
   "key": "ctrl+insert",
   "mac": "cmd+insert",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
-},
-{
-  "command": "leojs.insertChildNodeSelectionInterrupt",
-  "key": "ctrl+insert",
-  "mac": "cmd+insert",
-  "when": "!terminalFocus &amp;&amp; !panelFocus &amp;&amp; leojsTreeOpened &amp;&amp; !sideBarFocus &amp;&amp; !editorTextFocus"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.cloneNodeSelection",
@@ -6514,7 +6471,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "win": "ctrl+oem_3",
   "linux": "ctrl+`",
   "mac": "cmd+`",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/"
 },
 </t>
 <t tx="felix.20201214205159.77">{
@@ -6527,13 +6484,13 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.cutNodeSelectionFromOutline",
   "key": "ctrl+shift+x",
   "mac": "cmd+shift+x",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/"
 },
 {
   "command": "leojs.copyNodeSelection",
   "key": "ctrl+shift+c",
   "mac": "cmd+shift+c",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.pasteNodeAtSelection",
@@ -6545,7 +6502,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.pasteNodeAtSelectionFromOutline",
   "key": "ctrl+shift+v",
   "mac": "cmd+shift+v",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/"
 },
 {
   "command": "leojs.deleteSelection",
@@ -6557,7 +6514,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
   "command": "leojs.deleteSelectionFromOutline",
   "key": "ctrl+shift+backspace",
   "mac": "cmd+shift+backspace",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.deleteSelectionFromOutline",
@@ -6618,7 +6575,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.gotoNextCloneSelectionFromOutline",
   "key": "alt+n",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.gotoNextCloneSelection",
@@ -13999,18 +13956,18 @@ private _refreshGotoPane(): void {
   "command": "leojs.goAnywhere",
   "key": "ctrl+p",
   "mac": "cmd+p",
-  "when": "config.leojs.goAnywhereShortcut &amp;&amp; leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; !editorFocus &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/ || config.leojs.goAnywhereShortcut &amp;&amp; leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "config.leojs.goAnywhereShortcut &amp;&amp; leojsEditHeadline || config.leojs.goAnywhereShortcut &amp;&amp; leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; !editorFocus &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/ || config.leojs.goAnywhereShortcut &amp;&amp; leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.startSearch",
   "key": "ctrl+f",
   "mac": "cmd+f",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; !editorFocus &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; !editorFocus &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.findNextFromOutline",
   "key": "f3",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.findNext",
@@ -14020,7 +13977,7 @@ private _refreshGotoPane(): void {
 {
   "command": "leojs.findPreviousFromOutline",
   "key": "f2",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; !editorTextFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.findPrevious",
@@ -14037,7 +13994,7 @@ private _refreshGotoPane(): void {
   "command": "leojs.replaceFromOutline",
   "key": "ctrl+=",
   "mac": "cmd+=",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.replaceThenFind",
@@ -14049,78 +14006,78 @@ private _refreshGotoPane(): void {
   "command": "leojs.replaceThenFindFromOutline",
   "key": "ctrl+-",
   "mac": "cmd+-",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/"
 },
 {
   "command": "leojs.gotoGlobalLine",
   "key": "alt+g",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.setFindEverywhereOption",
   "key": "ctrl+alt+e",
   "mac": "cmd+alt+e",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.setFindNodeOnlyOption",
   "key": "ctrl+alt+n",
   "mac": "cmd+alt+n",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.setFindFileOnlyOption",
   "key": "ctrl+alt+l",
   "mac": "cmd+alt+l",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.setFindSuboutlineOnlyOption",
   "key": "ctrl+alt+s",
   "mac": "cmd+alt+s",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.toggleFindIgnoreCaseOption",
   "key": "ctrl+alt+i",
   "mac": "cmd+alt+i",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.toggleFindMarkChangesOption",
   "key": "ctrl+alt+c",
   "mac": "cmd+alt+c",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.toggleFindMarkFindsOption",
   "key": "ctrl+alt+f",
   "mac": "cmd+alt+f",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.toggleFindRegexpOption",
   "key": "ctrl+alt+x",
   "mac": "cmd+alt+x",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.toggleFindWordOption",
   "key": "ctrl+alt+w",
   "mac": "cmd+alt+w",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.toggleFindSearchBodyOption",
   "key": "ctrl+alt+b",
   "mac": "cmd+alt+b",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.toggleFindSearchHeadlineOption",
   "key": "ctrl+alt+h",
   "mac": "cmd+alt+h",
-  "when": "leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojs/ || leojsTreeOpened &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 </t>
 <t tx="felix.20221115220743.1">{
@@ -14753,12 +14710,15 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         this._hibResolve = p_resolve;
         // onDidHide handles CANCEL AND ACCEPT AND INTERCEPT !
         this._hibDisposables.push(hib.onDidHide(() =&gt; {
+            this.leoStates.leoEditHeadline = false;
             if (this._hibResolve) {
+                // RESOLVE whatever value was set otherwise undefined will mean 'canceled'.
                 this._hibResolve(this._hibLastValue);
-
+                // Dispose of everything disposable with the edit headline process.
                 for (const disp of this._hibDisposables) {
                     disp.dispose();
                 }
+                // Empty related global variables.
                 this._hibDisposables = [];
                 this._hibResolve = undefined;
                 this._hib = undefined;
@@ -14766,11 +14726,22 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         }, this));
         this._hibDisposables.push(hib);
 
-        // setup finished, show it! 
+        // setup finished, set command context and show it! 
         this._hib = hib;
+        this.leoStates.leoEditHeadline = true;
         this._hib.show();
     });
     return q_headlineInputBox;
+}
+
+</t>
+<t tx="felix.20231030200350.1">private _leoEditHeadline: boolean = false;
+get leoEditHeadline(): boolean {
+    return this._leoEditHeadline;
+}
+set leoEditHeadline(p_value: boolean) {
+    this._leoEditHeadline = p_value;
+    this.qLastContextChange = utils.setContext(Constants.CONTEXT_FLAGS.LEO_EDIT_HEADLINE, p_value);
 }
 
 </t>

--- a/leojs.leo
+++ b/leojs.leo
@@ -210,7 +210,6 @@
 <v t="felix.20220505215924.8"><vh>findSymbol</vh></v>
 <v t="felix.20220505215924.9"><vh>replace &amp; replaceThenFind</vh></v>
 <v t="felix.20230121211548.1"><vh>interactiveSearch</vh></v>
-<v t="felix.20220505215924.11"><vh>Find / Replace All</vh></v>
 <v t="felix.20220505215924.12"><vh>setSearchOption</vh></v>
 <v t="felix.20220505215924.13"><vh>loadSearchSettings</vh></v>
 <v t="felix.20220505215924.14"><vh>saveSearchSettings</vh></v>
@@ -3684,6 +3683,7 @@ export class LeoUI extends NullGui {
     private _hibResolve: undefined | ((value: string | PromiseLike&lt;string | undefined&gt; | undefined) =&gt; void);
     private _onDidHideResolve: undefined | ((value: PromiseLike&lt;void&gt; | undefined) =&gt; void);
     private _hibLastValue: undefined | string;
+    private _hibInterrupted = false;
     private _hibDisposables: vscode.Disposable[] = [];
 
     // * Timing
@@ -4230,22 +4230,23 @@ public async minibuffer(): Promise&lt;unknown&gt; {
  * @returns Thenable that resolves when done
  */
 public async editHeadline(p_node?: Position, p_fromOutline?: boolean, p_prompt?: string): Promise&lt;Position&gt; {
-    await this.triggerBodySave(true);
-    let w_finalFocus: Focus = p_fromOutline ? Focus.Outline : Focus.Body; // Use w_fromOutline for where we intend to leave focus when done with the insert
+    const c = g.app.windowList[this.frameIndex].c;
+    const u = c.undoer;
+    const w_p: Position = p_node || c.p;
 
-    // ! CHECK IF THIS IS NEEDED !
-    // TODO ?
-    // if (this._focusInterrupt) {
-    //     w_finalFocus = Focus.NoChange; // Going to use last state
-    // }
+    if (this._hib &amp;&amp; this._hib.enabled) {
+        return Promise.resolve(w_p); // DO NOT REACT IF ALREADY EDITING A HEADLINE! 
+    }
+
+    await this.triggerBodySave(true);
+
+    let w_finalFocus: Focus = p_fromOutline ? Focus.Outline : Focus.Body; // Use w_fromOutline for where we intend to leave focus when done with the insert
 
     this.setupRefresh(
         w_finalFocus,
         { tree: true, states: true }
     );
-    const c = g.app.windowList[this.frameIndex].c;
-    const u = c.undoer;
-    const w_p: Position = p_node || c.p;
+
     const w_headlineInputOptions: vscode.InputBoxOptions = {
         ignoreFocusOut: false,
         value: w_p.h,  // preset input pop up
@@ -4306,14 +4307,18 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
     const test = Math.floor(Math.random() * 10) + 1;
     console.log("starting", test);
 
-    await this.triggerBodySave(true);
-    console.log("after triggerBodySave", test);
+    let w_hadHib = false;
+    if (this._hib &amp;&amp; this._hib.enabled) {
+        w_hadHib = true;
+    }
 
     let w_finalFocus: Focus = p_fromOutline ? Focus.Outline : Focus.Body; // Use w_fromOutline for where we intend to leave focus when done with the insert
+    if (w_hadHib) {
+        this._focusInterrupt = true; // this will affect next refresh by triggerbodysave, not the refresh of this pass
+    }
 
-    // if (this._focusInterrupt) {
-    //     w_finalFocus = Focus.NoChange; // Going to use last state
-    // }
+    await this.triggerBodySave(true);
+    console.log("after triggerBodySave", test);
 
     const w_headlineInputOptions: vscode.InputBoxOptions = {
         ignoreFocusOut: false,
@@ -4325,6 +4330,14 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
     const p_newHeadline = await this._showHeadlineInputBox(w_headlineInputOptions);
     console.log('finished awaiting in insertNode in ', test);
     // * if node has child and is expanded: turn p_asChild to true!
+
+    // IF WE WERE INTERUPTED DO THIS:
+    //  w_finalFocus = Focus.NoChange; // Going to use last state
+    if (this._hibInterrupted) {
+        w_finalFocus = Focus.NoChange;
+        this._hibInterrupted = false;
+    }
+
 
     this.lastCommandTimer = process.hrtime();
     if (this.commandTimer === undefined) {
@@ -4375,8 +4388,9 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
         this._onDidHideResolve(undefined);
         this._onDidHideResolve = undefined;
     } else {
-        void this.launchRefresh();
+        // pass
     }
+    void this.launchRefresh();
 
     return value;
 
@@ -6607,7 +6621,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.gotoNextVisible",
   "key": "down",
-  "when": "config.leojs.leoTreeBrowse &amp;&amp; leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "config.leojs.leoTreeBrowse &amp;&amp; leojsEditHeadline || config.leojs.leoTreeBrowse &amp;&amp; leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.gotoNavNext",
@@ -6617,12 +6631,12 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.gotoNextVisible",
   "key": "alt+down",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsTreeOpened &amp;&amp; leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.gotoPrevVisible",
   "key": "up",
-  "when": "config.leojs.leoTreeBrowse &amp;&amp; leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
+  "when": "config.leojs.leoTreeBrowse &amp;&amp; leojsEditHeadline || config.leojs.leoTreeBrowse &amp;&amp; leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline/"
 },
 {
   "command": "leojs.gotoNavPrev",
@@ -6632,7 +6646,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.gotoPrevVisible",
   "key": "alt+up",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsTreeOpened &amp;&amp; leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.contractOrGoLeft",
@@ -6642,7 +6656,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.contractOrGoLeft",
   "key": "alt+left",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsTreeOpened &amp;&amp; leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 {
   "command": "leojs.expandAndGoRight",
@@ -6652,7 +6666,7 @@ public async insertNode(p_node: Position | undefined, p_fromOutline: boolean, p_
 {
   "command": "leojs.expandAndGoRight",
   "key": "alt+right",
-  "when": "leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
+  "when": "leojsTreeOpened &amp;&amp; leojsEditHeadline || leojsTreeOpened &amp;&amp; sideBarFocus &amp;&amp; focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened &amp;&amp; !editorHasSelection &amp;&amp; editorTextFocus &amp;&amp; resourceScheme == leojs"
 },
 </t>
 <t tx="felix.20201214205159.79">"cleanup": "node ./cleanup.js",
@@ -7519,9 +7533,7 @@ public gotSelectedNode(p_node: Position): void {
         let w_showBodyNoFocus: boolean = this.finalFocus.valueOf() !== Focus.Body; // Will preserve focus where it is without forcing into the body pane if true
         if (this._focusInterrupt) {
             this._focusInterrupt = false;
-            if (this.finalFocus.valueOf() !== Focus.Body) {
-                w_showBodyNoFocus = true; // TODO MAY BE NECESSARY ?
-            }
+            w_showBodyNoFocus = true;
         }
         if (!w_last || this._needLastSelectedRefresh) {
             // lastSelectedNode will be set in _tryApplyNodeToBody !
@@ -8783,23 +8795,17 @@ public triggerBodySave(p_forcedVsCodeSave?: boolean, p_fromFocusChange?: boolean
         functionName = (match &amp;&amp; match[1]) || "";
     }
     // * Check if headline edit input box is active. Validate it with current value.
-    if (!p_fromFocusChange &amp;&amp; this._hib &amp;&amp; this._hib.enabled &amp;&amp; this._hibInstances) {
-
-
-
-        console.log('++++++++++++ IN triggerBodySave HIB +++++++++++++ HIDING! from :', functionName, 'instances: ', this._hibInstances);
-
+    if (!p_fromFocusChange &amp;&amp; this._hib &amp;&amp; this._hib.enabled) {
+        console.log('++++++++++++ IN triggerBodySave HIB -&gt; HIDING! Was called from :', functionName, ' instances: ' + this._hibInstances.toString());
         if (this._hibInstances !== 1) {
-            console.log('ERROR this._hibInstances not 1 when hiding on triggerBodySave INTERRUPT:', this._hibInstances);
+            console.log('ERROR this._hibInstances not 1 when hiding on triggerBodySave INTERRUPT. instances: ' + this._hibInstances.toString());
         }
+        this._hibInterrupted = true;
         this._hib.enabled = false;
-
         this._hibLastValue = this._hib.value;
         this._hib.hide();
-        // TODO : CHECK IF DELAYED RESOLVE NEEDED !
         const w_resolveAfterEditHeadline = new Promise&lt;void&gt;((p_resolve, p_reject) =&gt; {
             this._onDidHideResolve = p_resolve;
-            this._focusInterrupt = true;
         });
         return w_resolveAfterEditHeadline;
     } else {
@@ -9744,108 +9750,6 @@ public async gotoNavEntry(p_node: LeoGotoNode): Promise&lt;unknown&gt; {
 }
 </t>
 <t tx="felix.20220505215924.1"></t>
-<t tx="felix.20220505215924.11">/**
- * * Find / Replace All
- * @returns Promise of LeoBridgePackage from execution or undefined if cancelled
- */
-public findAll(p_replace?: boolean): Thenable&lt;unknown&gt; {
-
-    let w_searchString: string = this._lastSettingsUsed!.findText;
-    let w_replaceString: string = this._lastSettingsUsed!.replaceText;
-
-    const w_startValue = this._lastSettingsUsed!.findText === Constants.USER_MESSAGES.FIND_PATTERN_HERE ? '' : this._lastSettingsUsed!.findText;
-    const w_startReplace = this._lastSettingsUsed?.replaceText;
-
-    return this.triggerBodySave(true)
-        .then((p_saveResult) =&gt; {
-            return this._inputFindPattern(false, w_startValue)
-                .then((p_findString) =&gt; {
-                    if (!p_findString) {
-                        return true; // Cancelled with escape or empty string.
-                    }
-                    w_searchString = p_findString;
-                    if (p_replace) {
-                        return this._inputFindPattern(true, w_startReplace).then((p_replaceString) =&gt; {
-                            if (p_replaceString === undefined) {
-                                return true;
-                            }
-                            w_replaceString = p_replaceString;
-                            return false;
-                        });
-                    }
-                    return false;
-                });
-        })
-        .then((p_cancelled: boolean) =&gt; {
-            if (this._lastSettingsUsed &amp;&amp; !p_cancelled) {
-                this._lastSettingsUsed.findText = w_searchString;
-                this._lastSettingsUsed.replaceText = w_replaceString;
-
-                // * savesettings not needed, w_changeSettings is used directly
-                void this.saveSearchSettings(this._lastSettingsUsed); // No need to wait, will be stacked.
-
-                const c = g.app.windowList[this.frameIndex].c;
-                const fc = c.findCommands;
-
-                fc.ftm.get_settings(); // TODO REMOVE?? 
-
-                const w_changeSettings: ISettings = {
-                    // this._lastSettingsUsed
-                    // State...
-                    in_headline: false, // ! TODO !
-                    // p: Position,
-                    // Find/change strings...
-                    find_text: this._lastSettingsUsed.findText,
-                    change_text: this._lastSettingsUsed.replaceText,
-                    // Find options...
-                    file_only: this._lastSettingsUsed.searchOptions === 3,
-                    ignore_case: this._lastSettingsUsed.ignoreCase,
-                    mark_changes: this._lastSettingsUsed.markChanges,
-                    mark_finds: this._lastSettingsUsed.markFinds,
-                    node_only: this._lastSettingsUsed.searchOptions === 2,
-                    pattern_match: this._lastSettingsUsed.regExp,
-                    reverse: false,
-                    search_body: this._lastSettingsUsed.searchBody,
-                    search_headline: this._lastSettingsUsed.searchHeadline,
-                    suboutline_only: this._lastSettingsUsed.searchOptions === 1,
-                    whole_word: this._lastSettingsUsed.wholeWord,
-                    wrapping: false, // unused
-                };
-
-                let w_result;
-                if (p_replace) {
-                    w_result = fc.do_change_all(w_changeSettings);
-                } else {
-                    w_result = fc.do_find_all(w_changeSettings);
-                }
-
-                const w_focus = this._get_focus();
-
-                let w_finalFocus = Focus.Body;
-
-                if (w_focus.includes('tree') || w_focus.includes('head')) {
-                    // tree
-                    w_finalFocus = Focus.Outline;
-                }
-                this.loadSearchSettings();
-                this.setupRefresh(
-                    w_finalFocus,
-                    {
-                        tree: true,
-                        body: true,
-                        // documents: false,
-                        // buttons: false,
-                        states: true
-                    }
-                );
-                void this.launchRefresh();
-                return;
-
-            }
-        });
-}
-
-</t>
 <t tx="felix.20220505215924.12">/**
  * * Set search setting in the search webview
  * @param p_id string id of the setting name
@@ -14734,9 +14638,9 @@ Although legal in js, it is NOT equivalent: A "for in" loop in js loops over the
  */
 private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;string | undefined&gt; {
     if (this._hibInstances) {
-        console.log('ERROR this._hibInstances is not zero when creating input box!', this._hibInstances);
+        console.log('ERROR this._hibInstances is not zero when creating input box!  _hibInstances was: ' + this._hibInstances.toString());
     }
-    console.log('-------------------- IN _showHeadlineInputBox --------------------+');
+    console.log('-------------------- IN _showHeadlineInputBox _hibInstances was: ' + this._hibInstances.toString());
 
     const hib = vscode.window.createInputBox();
     this._hibLastValue = undefined; // Prepare for 'cancel' as default.
@@ -14747,11 +14651,12 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         hib.valueSelection = p_options.valueSelection;
         hib.prompt = p_options.prompt;
         this._hibDisposables.push(hib.onDidAccept(() =&gt; {
-            console.log('-------------------- IN onDidAccept --------------------+');
+
+            console.log('-------------------- IN onDidAccept _hibInstances was: ');
 
             if (this._hib) {
                 if (this._hibInstances !== 1) {
-                    console.log('ERROR this._hibInstances not 1 when hiding on accept', this._hibInstances);
+                    console.log('ERROR this._hibInstances not 1 when hiding on accept' + this._hibInstances.toString());
                 }
                 this._hib.enabled = false;
                 this._hibLastValue = this._hib.value;
@@ -14763,7 +14668,9 @@ private _showHeadlineInputBox(p_options: vscode.InputBoxOptions): Promise&lt;str
         this._hibResolve = p_resolve;
         // onDidHide handles CANCEL AND ACCEPT AND INTERCEPT !
         this._hibDisposables.push(hib.onDidHide(() =&gt; {
-            console.log('-------------------- IN onDidHide --------------------+ _hibInstances: ', this._hibInstances);
+
+            console.log('-------------------- IN onDidHide _hibInstances was: ' + this._hibInstances.toString());
+
             this._hibInstances -= 1;
             this.leoStates.leoEditHeadline = false;
             if (this._hibResolve) {

--- a/package.json
+++ b/package.json
@@ -1473,26 +1473,6 @@
         }
       },
       {
-        "command": "leojs.insertNodeSelectionInterrupt",
-        "category": "Leojs",
-        "title": "Insert Node",
-        "enablement": "leojsTreeOpened",
-        "icon": {
-          "light": "resources/light/plus.svg",
-          "dark": "resources/dark/plus.svg"
-        }
-      },
-      {
-        "command": "leojs.insertChildNodeSelectionInterrupt",
-        "category": "Leojs",
-        "title": "Insert Child",
-        "enablement": "leojsTreeOpened",
-        "icon": {
-          "light": "resources/light/insert-child.svg",
-          "dark": "resources/dark/insert-child.svg"
-        }
-      },
-      {
         "command": "leojs.cloneNode",
         "category": "Leojs",
         "title": "Clone Node",
@@ -2333,19 +2313,11 @@
           "when": "false"
         },
         {
-          "command": "leojs.insertNodeSelectionInterrupt",
-          "when": "false"
-        },
-        {
           "command": "leojs.insertChildNode",
           "when": "false"
         },
         {
           "command": "leojs.insertChildNodeSelectionFromOutline",
-          "when": "false"
-        },
-        {
-          "command": "leojs.insertChildNodeSelectionInterrupt",
           "when": "false"
         },
         {
@@ -2976,17 +2948,17 @@
         "command": "leojs.executeScript",
         "key": "ctrl+b",
         "mac": "cmd+b",
-        "when": "leojsTreeOpened && editorTextFocus && resourceScheme == leojs || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && editorTextFocus && resourceScheme == leojs || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.minibuffer",
         "key": "alt+x",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.showOutline",
         "key": "alt+t",
-        "when": "leojsTreeOpened && editorTextFocus && resourceScheme == leojs || leojsFindFocus || focusedView =~ /^leojsUndos|^leojsFindPanel|^leojsDocuments|^leojsGoto|^leojsButtons/"
+        "when": "leojsEditHeadline || leojsTreeOpened && editorTextFocus && resourceScheme == leojs || leojsFindFocus || focusedView =~ /^leojsUndos|^leojsFindPanel|^leojsDocuments|^leojsGoto|^leojsButtons/"
       },
       {
         "command": "leojs.showOutline",
@@ -3003,13 +2975,13 @@
       {
         "command": "leojs.showBody",
         "key": "alt+d",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.showBody",
         "key": "ctrl+g",
         "mac": "cmd+g",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.showBody",
@@ -3025,13 +2997,13 @@
         "command": "leojs.tabCycleNext",
         "key": "ctrl+tab",
         "mac": "cmd+tab",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.saveLeoFileFromOutline",
         "key": "ctrl+s",
         "mac": "cmd+s",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.saveLeoFile",
@@ -3043,13 +3015,13 @@
         "command": "leojs.newLeoFile",
         "key": "ctrl+n",
         "mac": "cmd+n",
-        "when": "editorTextFocus && resourceScheme == leojs || leojsFindFocus || sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || editorTextFocus && resourceScheme == leojs || leojsFindFocus || sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.openLeoFile",
         "key": "ctrl+o",
         "mac": "cmd+o",
-        "when": "editorTextFocus && resourceScheme == leojs || leojsFindFocus || sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || editorTextFocus && resourceScheme == leojs || leojsFindFocus || sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.writeAtFileNodes",
@@ -3061,7 +3033,7 @@
         "command": "leojs.writeAtFileNodesFromOutline",
         "key": "ctrl+shift+w",
         "mac": "cmd+shift+w",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.writeDirtyAtFileNodes",
@@ -3073,7 +3045,7 @@
         "command": "leojs.writeDirtyAtFileNodesFromOutline",
         "key": "ctrl+shift+q",
         "mac": "cmd+shift+q",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.contractAll",
@@ -3083,7 +3055,7 @@
       {
         "command": "leojs.contractAllFromOutline",
         "key": "alt+-",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.editSelectedHeadline",
@@ -3095,7 +3067,7 @@
         "command": "leojs.editSelectedHeadlineFromOutline",
         "key": "ctrl+h",
         "mac": "cmd+h",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments|^leojsButtons|^leojsUndos/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments|^leojsButtons|^leojsUndos/"
       },
       {
         "command": "leojs.markSelection",
@@ -3107,7 +3079,7 @@
         "command": "leojs.markSelectionFromOutline",
         "key": "ctrl+m",
         "mac": "cmd+m",
-        "when": "leojsTreeOpened && !leojsMarked && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && !leojsMarked && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.unmarkSelection",
@@ -3119,19 +3091,19 @@
         "command": "leojs.unmarkSelectionFromOutline",
         "key": "ctrl+m",
         "mac": "cmd+m",
-        "when": "leojsTreeOpened && leojsMarked && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && leojsMarked && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.extract",
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/ || leojsTreeOpened && editorTextFocus && editorHasSelection && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/ || leojsTreeOpened && editorTextFocus && editorHasSelection && resourceScheme == leojs"
       },
       {
         "command": "leojs.extractNames",
         "key": "ctrl+shift+n",
         "mac": "cmd+shift+n",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/ || leojsTreeOpened && editorTextFocus && editorHasSelection && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/ || leojsTreeOpened && editorTextFocus && editorHasSelection && resourceScheme == leojs"
       },
       {
         "command": "leojs.moveOutlineDownSelection",
@@ -3149,7 +3121,7 @@
         "command": "leojs.moveOutlineDownSelectionFromOutline",
         "key": "ctrl+d",
         "mac": "cmd+d",
-        "when": "leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.moveOutlineDownSelectionFromOutline",
@@ -3178,7 +3150,7 @@
         "command": "leojs.moveOutlineLeftSelectionFromOutline",
         "key": "ctrl+l",
         "mac": "cmd+l",
-        "when": "leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.moveOutlineLeftSelectionFromOutline",
@@ -3207,7 +3179,7 @@
         "command": "leojs.moveOutlineRightSelectionFromOutline",
         "key": "ctrl+r",
         "mac": "cmd+r",
-        "when": "leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.moveOutlineRightSelectionFromOutline",
@@ -3236,7 +3208,7 @@
         "command": "leojs.moveOutlineUpSelectionFromOutline",
         "key": "ctrl+u",
         "mac": "cmd+u",
-        "when": "leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && !editorHasSelection && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.moveOutlineUpSelectionFromOutline",
@@ -3257,7 +3229,7 @@
       {
         "command": "leojs.sortSiblingsSelectionFromOutline",
         "key": "alt+a",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.promoteSelection",
@@ -3273,7 +3245,7 @@
         "win": "ctrl+oem_4",
         "linux": "ctrl+[",
         "mac": "cmd+[BracketLeft]",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.demoteSelection",
@@ -3289,7 +3261,7 @@
         "win": "ctrl+oem_6",
         "linux": "ctrl+]",
         "mac": "cmd+[BracketRight]",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.insertNodeSelection",
@@ -3301,13 +3273,7 @@
         "command": "leojs.insertNodeSelectionFromOutline",
         "key": "ctrl+i",
         "mac": "cmd+i",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
-      },
-      {
-        "command": "leojs.insertNodeSelectionInterrupt",
-        "key": "ctrl+i",
-        "mac": "cmd+i",
-        "when": "!terminalFocus && !panelFocus && leojsTreeOpened && !sideBarFocus && !editorTextFocus"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.insertNodeSelection",
@@ -3319,19 +3285,13 @@
         "command": "leojs.insertNodeSelectionFromOutline",
         "key": "shift+insert",
         "mac": "shift+insert",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.insertNodeSelectionFromOutline",
         "key": "insert",
         "mac": "insert",
         "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
-      },
-      {
-        "command": "leojs.insertNodeSelectionInterrupt",
-        "key": "shift+insert",
-        "mac": "shift+insert",
-        "when": "!terminalFocus && !panelFocus && leojsTreeOpened && !sideBarFocus && !editorTextFocus"
       },
       {
         "command": "leojs.insertChildNodeSelection",
@@ -3343,13 +3303,7 @@
         "command": "leojs.insertChildNodeSelectionFromOutline",
         "key": "ctrl+insert",
         "mac": "cmd+insert",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
-      },
-      {
-        "command": "leojs.insertChildNodeSelectionInterrupt",
-        "key": "ctrl+insert",
-        "mac": "cmd+insert",
-        "when": "!terminalFocus && !panelFocus && leojsTreeOpened && !sideBarFocus && !editorTextFocus"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.cloneNodeSelection",
@@ -3365,7 +3319,7 @@
         "win": "ctrl+oem_3",
         "linux": "ctrl+`",
         "mac": "cmd+`",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/"
       },
       {
         "command": "leojs.cutNodeSelection",
@@ -3377,13 +3331,13 @@
         "command": "leojs.cutNodeSelectionFromOutline",
         "key": "ctrl+shift+x",
         "mac": "cmd+shift+x",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/"
       },
       {
         "command": "leojs.copyNodeSelection",
         "key": "ctrl+shift+c",
         "mac": "cmd+shift+c",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.pasteNodeAtSelection",
@@ -3395,7 +3349,7 @@
         "command": "leojs.pasteNodeAtSelectionFromOutline",
         "key": "ctrl+shift+v",
         "mac": "cmd+shift+v",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/"
       },
       {
         "command": "leojs.deleteSelection",
@@ -3407,7 +3361,7 @@
         "command": "leojs.deleteSelectionFromOutline",
         "key": "ctrl+shift+backspace",
         "mac": "cmd+shift+backspace",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.deleteSelectionFromOutline",
@@ -3430,18 +3384,18 @@
         "command": "leojs.goAnywhere",
         "key": "ctrl+p",
         "mac": "cmd+p",
-        "when": "config.leojs.goAnywhereShortcut && leojsTreeOpened && sideBarFocus && !editorFocus && !editorTextFocus && focusedView =~ /^leojs/ || config.leojs.goAnywhereShortcut && leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "config.leojs.goAnywhereShortcut && leojsEditHeadline || config.leojs.goAnywhereShortcut && leojsTreeOpened && sideBarFocus && !editorFocus && !editorTextFocus && focusedView =~ /^leojs/ || config.leojs.goAnywhereShortcut && leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.startSearch",
         "key": "ctrl+f",
         "mac": "cmd+f",
-        "when": "leojsTreeOpened && sideBarFocus && !editorFocus && !editorTextFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && !editorFocus && !editorTextFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.findNextFromOutline",
         "key": "f3",
-        "when": "leojsFindFocus || leojsTreeOpened && !editorTextFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && !editorTextFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.findNext",
@@ -3451,7 +3405,7 @@
       {
         "command": "leojs.findPreviousFromOutline",
         "key": "f2",
-        "when": "leojsFindFocus || leojsTreeOpened && !editorTextFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && !editorTextFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.findPrevious",
@@ -3468,7 +3422,7 @@
         "command": "leojs.replaceFromOutline",
         "key": "ctrl+=",
         "mac": "cmd+=",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.replaceThenFind",
@@ -3480,78 +3434,78 @@
         "command": "leojs.replaceThenFindFromOutline",
         "key": "ctrl+-",
         "mac": "cmd+-",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/"
       },
       {
         "command": "leojs.gotoGlobalLine",
         "key": "alt+g",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.setFindEverywhereOption",
         "key": "ctrl+alt+e",
         "mac": "cmd+alt+e",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.setFindNodeOnlyOption",
         "key": "ctrl+alt+n",
         "mac": "cmd+alt+n",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.setFindFileOnlyOption",
         "key": "ctrl+alt+l",
         "mac": "cmd+alt+l",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.setFindSuboutlineOnlyOption",
         "key": "ctrl+alt+s",
         "mac": "cmd+alt+s",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.toggleFindIgnoreCaseOption",
         "key": "ctrl+alt+i",
         "mac": "cmd+alt+i",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.toggleFindMarkChangesOption",
         "key": "ctrl+alt+c",
         "mac": "cmd+alt+c",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.toggleFindMarkFindsOption",
         "key": "ctrl+alt+f",
         "mac": "cmd+alt+f",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.toggleFindRegexpOption",
         "key": "ctrl+alt+x",
         "mac": "cmd+alt+x",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.toggleFindWordOption",
         "key": "ctrl+alt+w",
         "mac": "cmd+alt+w",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.toggleFindSearchBodyOption",
         "key": "ctrl+alt+b",
         "mac": "cmd+alt+b",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.toggleFindSearchHeadlineOption",
         "key": "ctrl+alt+h",
         "mac": "cmd+alt+h",
-        "when": "leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsEditHeadline || leojsFindFocus || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojs/ || leojsTreeOpened && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.gotoFirstVisible",
@@ -3606,7 +3560,7 @@
       {
         "command": "leojs.gotoNextCloneSelectionFromOutline",
         "key": "alt+n",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.gotoNextCloneSelection",

--- a/package.json
+++ b/package.json
@@ -3570,7 +3570,7 @@
       {
         "command": "leojs.gotoNextVisible",
         "key": "down",
-        "when": "config.leojs.leoTreeBrowse && leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "config.leojs.leoTreeBrowse && leojsEditHeadline || config.leojs.leoTreeBrowse && leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.gotoNavNext",
@@ -3580,12 +3580,12 @@
       {
         "command": "leojs.gotoNextVisible",
         "key": "alt+down",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsTreeOpened && leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.gotoPrevVisible",
         "key": "up",
-        "when": "config.leojs.leoTreeBrowse && leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
+        "when": "config.leojs.leoTreeBrowse && leojsEditHeadline || config.leojs.leoTreeBrowse && leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline/"
       },
       {
         "command": "leojs.gotoNavPrev",
@@ -3595,7 +3595,7 @@
       {
         "command": "leojs.gotoPrevVisible",
         "key": "alt+up",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsTreeOpened && leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.contractOrGoLeft",
@@ -3605,7 +3605,7 @@
       {
         "command": "leojs.contractOrGoLeft",
         "key": "alt+left",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsTreeOpened && leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "leojs.expandAndGoRight",
@@ -3615,7 +3615,7 @@
       {
         "command": "leojs.expandAndGoRight",
         "key": "alt+right",
-        "when": "leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
+        "when": "leojsTreeOpened && leojsEditHeadline || leojsTreeOpened && sideBarFocus && focusedView =~ /^leojsOutline|^leojsDocuments/ || leojsTreeOpened && !editorHasSelection && editorTextFocus && resourceScheme == leojs"
       },
       {
         "command": "workbench.files.action.collapseExplorerFolders",

--- a/src/commandBindings.ts
+++ b/src/commandBindings.ts
@@ -157,19 +157,19 @@ export function makeAllBindings(p_leoUI: LeoUI, p_context: vscode.ExtensionConte
         [CMD.CHAPTER_MAIN, () => p_leoUI.command(LEOCMD.CHAPTER_MAIN, { refreshType: REFRESH_TREE_BODY, finalFocus: Focus.NoChange })],
         [CMD.CHAPTER_SELECT, () => p_leoUI.command(LEOCMD.CHAPTER_SELECT, { refreshType: REFRESH_TREE_BODY, finalFocus: Focus.NoChange })],
 
-        [CMD.INSERT, (p_node: Position) => p_leoUI.insertNode(p_node, true, false, false)],
-        [CMD.INSERT_SELECTION, () => p_leoUI.insertNode(U, false, false, false)],
-        [CMD.INSERT_SELECTION_FO, () => p_leoUI.insertNode(U, true, false, false)],
+        [CMD.INSERT, (p_node: Position) => p_leoUI.insertNode(p_node, true, false)],
+        [CMD.INSERT_SELECTION, () => p_leoUI.insertNode(U, false, false)],
+        [CMD.INSERT_SELECTION_FO, () => p_leoUI.insertNode(U, true, false)],
         // Special command for when inserting rapidly more than one node without
         // even specifying a headline label, e.g. spamming CTRL+I rapidly.
-        [CMD.INSERT_SELECTION_INTERRUPT, () => p_leoUI.insertNode(U, false, true, false)],
+        // [CMD.INSERT_SELECTION_INTERRUPT, () => p_leoUI.insertNode(U, false, true, false)],
 
-        [CMD.INSERT_CHILD, (p_node: Position) => p_leoUI.insertNode(p_node, true, false, true)],
-        [CMD.INSERT_CHILD_SELECTION, () => p_leoUI.insertNode(U, false, false, true)],
-        [CMD.INSERT_CHILD_SELECTION_FO, () => p_leoUI.insertNode(U, true, false, true)],
+        [CMD.INSERT_CHILD, (p_node: Position) => p_leoUI.insertNode(p_node, true, true)],
+        [CMD.INSERT_CHILD_SELECTION, () => p_leoUI.insertNode(U, false, true)],
+        [CMD.INSERT_CHILD_SELECTION_FO, () => p_leoUI.insertNode(U, true, true)],
         // Special command for when inserting rapidly more than one node without
         // even specifying a headline label, e.g. spamming CTRL+I rapidly.
-        [CMD.INSERT_CHILD_SELECTION_INTERRUPT, () => p_leoUI.insertNode(U, false, true, true)],
+        // [CMD.INSERT_CHILD_SELECTION_INTERRUPT, () => p_leoUI.insertNode(U, false, true, true)],
 
         [CMD.CLONE, (p_node: Position) => p_leoUI.command(LEOCMD.CLONE_PNODE, { node: p_node, refreshType: REFRESH_TREE_BODY, finalFocus: Focus.Outline, keepSelection: true })],
         [CMD.CLONE_SELECTION, () => p_leoUI.command(LEOCMD.CLONE_PNODE, { refreshType: REFRESH_TREE, finalFocus: Focus.Body })],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -380,6 +380,7 @@ export class Constants {
         LEO_CAN_DEHOIST: "leojsCanDehoist",
         LEO_CAN_HOIST: "leojsCanHoist", // isNotRoot equivalent, Computed by hand
         LEO_TOP_HOIST_CHAPTER: "leojsTopHoistChapter",
+        LEO_EDIT_HEADLINE: "leojsEditHeadline",
 
         // 'states' flags about current selection, for visibility and commands availability
         SELECTED_MARKED: "leojsMarked", // no need for unmarked here, use !leojsMarked

--- a/src/core/leoGlobals.ts
+++ b/src/core/leoGlobals.ts
@@ -4463,10 +4463,10 @@ export function dedent(text: string): string {
 }
 //@+node:felix.20230925180832.1: *3* g.issueSecurityWarning
 export function issueSecurityWarning(setting: string): void {
-    es('Security warning! Ignoring...')
-    es(setting)
-    es('This setting can be set only in')
-    es('leoSettings.leo or myLeoSettings.leo')
+    es('Security warning! Ignoring...');
+    es(setting);
+    es('This setting can be set only in');
+    es('leoSettings.leo or myLeoSettings.leo');
 }
 //@+node:felix.20221218195057.1: *3* g.reEscape
 

--- a/src/core/leoImport.ts
+++ b/src/core/leoImport.ts
@@ -2579,7 +2579,7 @@ export class RecursiveImportController {
                 this.kind
             )
         ) {
-            this.error(`bad kind param: {self.kind}`)
+            this.error(`bad kind param: {self.kind}`);
             return;
         }
 

--- a/src/core/leoUndo.ts
+++ b/src/core/leoUndo.ts
@@ -2044,7 +2044,7 @@ export class Undoer {
         // Remember these values.
         const oldSel: number[] = u.oldSel;
         const p: Position = u.p!.copy();
-        const newP = u.newP.copy()  // Must exist now, but may not exist later.
+        const newP = u.newP.copy();  // Must exist now, but may not exist later.
         if (g.unitTesting) {
             g.assert(c.positionExists(newP), newP.toString());
         }

--- a/src/importers/base_importer.ts
+++ b/src/importers/base_importer.ts
@@ -437,7 +437,7 @@ export class Importer {
             parent.b = this.compute_body(outer_block.lines);
             return;
         }
-        outer_block.v = parent.v
+        outer_block.v = parent.v;
 
         // The main loop
         let todo_list: Block[] = [outer_block];

--- a/src/importers/python.ts
+++ b/src/importers/python.ts
@@ -24,7 +24,7 @@ export class Python_Importer extends Importer {
    * USED IN MATCH IN ORIGINAL LEO, SO ADDED '^' TO MATCH BEGINNING OF STRING
    */
   public async_def_pat = /^\s*async\s+def\s+(\w+)\s*\(/;
-  public def_pat = /^\s*def\s+(\w+)\s*\(/
+  public def_pat = /^\s*def\s+(\w+)\s*\(/;
   public class_pat = /^\s*class\s+(\w+)/;
 
   public block_patterns: [string, RegExp][] = [

--- a/src/leoStates.ts
+++ b/src/leoStates.ts
@@ -183,6 +183,15 @@ export class LeoStates {
         this.qLastContextChange = utils.setContext(Constants.CONTEXT_FLAGS.LEO_TOP_HOIST_CHAPTER, p_value);
     }
 
+    private _leoEditHeadline: boolean = false;
+    get leoEditHeadline(): boolean {
+        return this._leoEditHeadline;
+    }
+    set leoEditHeadline(p_value: boolean) {
+        this._leoEditHeadline = p_value;
+        this.qLastContextChange = utils.setContext(Constants.CONTEXT_FLAGS.LEO_EDIT_HEADLINE, p_value);
+    }
+
     // * 'states' flags about current selection, for visibility and commands availability
     private _leoMarked: boolean = false;
     get leoMarked(): boolean {

--- a/src/test/leoCommanderFileCommands.test.ts
+++ b/src/test/leoCommanderFileCommands.test.ts
@@ -48,7 +48,7 @@ suite('Test cases for commanderFileCommands.ts', () => {
          */
         const dummy_precheck = (fileName: string, root: any): Promise<boolean> => {
             return Promise.resolve(true);
-        }
+        };
 
         at.precheck = dummy_precheck;  // Force all writes.
 

--- a/src/test/leoCommands.test.ts
+++ b/src/test/leoCommands.test.ts
@@ -477,16 +477,16 @@ suite('Test cases for leoCommands.ts', () => {
         assert.ok(w_path.endsWith(endpath), `expected '${endpath}' got '${path}'`);
 
         // Test 2: Create a commander for an outline outside of g.app.loadDir and its parents.
-        c = new Commands('~/LeoPyRef.leo', g.app.gui)
-        child = p.insertAfter()
-        child.h = '@path one'
-        grand = child.insertAsLastChild()
-        grand.h = '@path two'
-        great = grand.insertAsLastChild()
-        great.h = 'xyz'
-        aList = g.get_directives_dict_list(great)
-        w_path = c.scanAtPathDirectives(aList)
-        endpath = g.os_path_normpath('one/two')
+        c = new Commands('~/LeoPyRef.leo', g.app.gui);
+        child = p.insertAfter();
+        child.h = '@path one';
+        grand = child.insertAsLastChild();
+        grand.h = '@path two';
+        great = grand.insertAsLastChild();
+        great.h = 'xyz';
+        aList = g.get_directives_dict_list(great);
+        w_path = c.scanAtPathDirectives(aList);
+        endpath = g.os_path_normpath('one/two');
         assert.ok(w_path.endsWith(endpath), `expected '${endpath}' got '${path}'`);
 
     });

--- a/src/test/test_importers.test.ts
+++ b/src/test/test_importers.test.ts
@@ -621,7 +621,7 @@ suite('TestC', () => {
             // self.skipTest(`Not found: ${w_path}`);
         }
 
-        assert.ok(false, "THE CODON FILE ACTUALLY EXISTS IN THE TESTS!")
+        assert.ok(false, "THE CODON FILE ACTUALLY EXISTS IN THE TESTS!");
 
 
         // // with open(path, 'r') as f
@@ -3068,7 +3068,7 @@ suite('TestPerl', () => {
                 '";\n' +
                 '            }\n'
             ],
-        ]
+        ];
         await self.new_run_test(s, expected_results);
     });
     //@+node:felix.20230922223249.3: *3* TestPerl.test_multi_line_string
@@ -3101,7 +3101,7 @@ suite('TestPerl', () => {
                 '@language perl\n' +
                 '@tabwidth -4\n'
             ],
-        ]
+        ];
         await self.new_run_test(s, expected_results);
     });
     //@+node:felix.20230922223249.4: *3* TestPerl.test_perlpod_comment
@@ -3310,7 +3310,7 @@ suite('TestPhp', () => {
             }
             ?>
         `;
-        await self.new_round_trip_test(s)
+        await self.new_round_trip_test(s);
 
     });
     //@+node:felix.20230922223256.5: *3* TestPhp.test_here_doc
@@ -4396,7 +4396,7 @@ suite('TestRust', () => {
                 '    width * height\n' +
                 '}\n'
             ],
-        ]
+        ];
         await self.new_run_test(s, expected_results);
     });
     //@-others


### PR DESCRIPTION
Headline editing (when inserting nodes, or renaming nodes) can now be interrupted by most commands and chained properly.